### PR TITLE
806958: BadCertificateException not displaying properly.

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -64,6 +64,9 @@ class BadCertificateException(ConnectionException):
         """ Pass the full path to the bad certificate. """
         self.cert_path = cert_path
 
+    def __str__(self):
+        return "Bad certificate at %s" % self.cert_path
+
 
 class RestlibException(ConnectionException):
 


### PR DESCRIPTION
The **str** function added to BadCertificateException does not need
to be internationalized since this message should only appear in
the logs.
