### PR TITLE
822965 - subscription-manager release does not work with proxies

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -178,7 +178,7 @@ class ContentConnection(object):
         else:
             conn = httpslib.HTTPSConnection(self.host, self.ssl_port, ssl_context=context)
 
-        conn.request("GET", handler, body="", headers={"Content-Length": "0"})
+        conn.request("GET", handler, body="", headers={"Host": "%s:%s" % (self.host, self.ssl_port), "Content-Length": "0"} )
         response = conn.getresponse()
         result = {
             "content": response.read(),


### PR DESCRIPTION
We were not sending the "Host" header up to the CDN when we were getting the
list of releases via a proxy. A certain CDN provider is very picky about this.
