### PR TITLE
825952: Error after deleting consumer at server

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -84,7 +84,7 @@ class GoneException(RestlibException):
     candlepin side.
     """
     def __init__(self, code, msg, deleted_id):
-        super(GoneException, self).__init__(code, msg)
+        RestlibException.__init__(self, code, msg)
         self.deleted_id = deleted_id
 
 


### PR DESCRIPTION
super() not available in RHEL 5.9 python version.
