### PR TITLE
834108: Set the default connection timeout to 1 min.

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -45,6 +45,8 @@ DEFAULTS = {
                 'proxy_port': '',
                 'proxy_user': '',
                 'proxy_password': '',
+                # timeout in seconds (float)
+                'connection_timeout': '60.0',
                 'insecure': '0',
                 'baseurl': 'https://cdn.redhat.com',
                 'manage_repos': '1',


### PR DESCRIPTION
httplib in python <= 2.4 seems to have a very long timeout
of around 3 mins. When an invalid proxy or server address
is configured, this feels way to long in both the CLI and
UI.

This value can be changed by adding a 'connection_timeout'
property under the 'server' section of the config file.
