### PR TITLE
834108: Set the default connection timeout to 1 min.

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -28,11 +28,11 @@ from urllib import urlencode
 
 from config import initConfig
 
-# on EL5, there is no/a really long socket timeout. The
+# on EL5, there is a really long socket timeout. The
 # best thing we can do is set a process wide default socket timeout.
-# limit this to affected python versions only, just to minimize any
+# Limit this to affected python versions only, just to minimize any
 # problems the default timeout might cause.
-if sys.version_info.major == 2 and sys.version_info.minor <= 4:
+if sys.version_info[0] == 2 and sys.version_info[0] <= 4:
     socket.setdefaulttimeout(60)
 
 


### PR DESCRIPTION
httplib in python <= 2.4 seems to have a very long timeout of around 3 mins.
When an invalid proxy or server address is configured, this feels way to long
in both the CLI and UI.

Set the default timeout to 60 seconds, but only on python 2.4 or less.
