### PR TITLE
Fix None product architectures.

### DIFF
--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -484,6 +484,8 @@ class Product(object):
         # can technically be multi-valued:
         if isinstance(self.architectures, str):
             self.architectures = parse_tags(self.architectures)
+        if self.architectures is None:
+            self.architectures = []
 
         self.provided_tags = provided_tags
         if self.provided_tags is None:

--- a/test/unit/certificate2-tests.py
+++ b/test/unit/certificate2-tests.py
@@ -174,5 +174,7 @@ class ProductTests(unittest.TestCase):
         self.assertEquals("i386", p.architectures[0])
         self.assertEquals("x86_64", p.architectures[1])
 
-
-
+    def test_none_arch(self):
+        p = Product(id="pid", name="pname")
+        self.assertTrue(p.architectures is not None)
+        self.assertTrue(isinstance(p.architectures, list))


### PR DESCRIPTION
This was coming out None for v1 certs with no arches defined.
