### PR TITLE
830767: Add __str__ method to RemoteServerException.

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -107,6 +107,9 @@ class RemoteServerException(ConnectionException):
     def __init__(self, code):
         self.code = code
 
+    def __str__(self):
+        return "Server returned %s" % self.code
+
 
 class NoOpChecker:
 


### PR DESCRIPTION
No i18n is required as this message should only appear in the logs.
