### PR TITLE
790481: Send up headers with the subscription-manager and python-rhsm ve...

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -27,6 +27,7 @@ from M2Crypto import SSL, httpslib
 from urllib import urlencode
 
 from config import initConfig
+from version import Versions
 
 # on EL5, there is a really long socket timeout. The
 # best thing we can do is set a process wide default socket timeout.
@@ -274,8 +275,18 @@ class Restlib(object):
         self.ssl_port = ssl_port
         self.apihandler = apihandler
         lc = _get_locale()
+        #collect some version data
+        v = Versions()
+        smVersion = ("%s-%s") % \
+            (v.get_version("subscription-manager"), v.get_release("subscription-manager"))
+        prVersion = ("%s-%s") % \
+            (v.get_version("python-rhsm"), v.get_release("python-rhsm"))
+
         self.headers = {"Content-type": "application/json",
-                        "Accept": "application/json"}
+                        "Accept": "application/json",
+                        "x-python-rhsm-version": prVersion,
+                        "x-subscription-manager-version": smVersion}
+
         if lc:
             self.headers["Accept-Language"] = lc.lower().replace('_', '-')
 

--- a/src/rhsm/version.py
+++ b/src/rhsm/version.py
@@ -38,13 +38,16 @@ class Versions(object):
 
         # We only want to initialize this data once.
         if not self.__initialized:
-            self._version_info = {}
             self.__initialized = True
+            self._collect_data()
 
-            for package_def in self._get_packages():
-                name = package_def['name']
-                if name in self.__to_collect:
-                    self._version_info[name] = package_def
+    def _collect_data(self):
+        self._version_info = {}
+
+        for package_def in self._get_packages():
+            name = package_def['name']
+            if name in self.__to_collect:
+                self._version_info[name] = package_def
 
     def _get_packages(self):
         profile = RPMProfile()

--- a/test/unit/version_tests.py
+++ b/test/unit/version_tests.py
@@ -25,6 +25,10 @@ NOT_COLLECTED = "non-collected-package"
 # only once.
 class VersionsStub(Versions):
 
+    def __init__(self):
+        super(VersionsStub, self).__init__()
+        self._collect_data()
+
     def _get_packages(self):
         package_set = [
             {'name': Versions.SUBSCRIPTION_MANAGER, 'version':'1', 'release': "1"},


### PR DESCRIPTION
...rsion info.

The headers will look like this:

  x-subscription-manager-version: 1.1.1-1.git.7.e8631ec.fc17
  x-python-rhsm-version: 1.1.3-1.git.1.4c46ecf.fc17
