### PR TITLE
pep8 test fixes

### DIFF
--- a/test/functional/profile-tests.py
+++ b/test/functional/profile-tests.py
@@ -30,13 +30,13 @@ class ProfileTests(unittest.TestCase):
         self.assertTrue(len(pkg_dicts) > 10)
 
         for pkg in pkg_dicts:
-            self.assertTrue(pkg.has_key('name'))
-            self.assertTrue(pkg.has_key('version'))
-            self.assertTrue(pkg.has_key('version'))
-            self.assertTrue(pkg.has_key('release'))
-            self.assertTrue(pkg.has_key('epoch'))
-            self.assertTrue(pkg.has_key('arch'))
-            self.assertTrue(pkg.has_key('vendor'))
+            self.assertTrue('name' in pkg)
+            self.assertTrue('version' in pkg)
+            self.assertTrue('version' in pkg)
+            self.assertTrue('release' in pkg)
+            self.assertTrue('epoch' in pkg)
+            self.assertTrue('arch' in pkg)
+            self.assertTrue('vendor' in pkg)
 
     def test_package_objects(self):
         profile = get_profile("rpm")

--- a/test/unit/bitstream-tests.py
+++ b/test/unit/bitstream-tests.py
@@ -24,6 +24,7 @@ decompresser = zlib.decompressobj()
 decompresser.decompress(entitlement_data)
 tree_data = decompresser.unused_data
 
+
 class TestGhettoBitStream(unittest.TestCase):
     def setUp(self):
         self.bs = GhettoBitStream(tree_data)
@@ -72,4 +73,3 @@ class TestGhettoBitStream(unittest.TestCase):
         self.assertEqual(self.bs.combine_bytes([1, 3]), 259)
         self.assertEqual(self.bs.combine_bytes([3]), 3)
         self.assertEqual(self.bs.combine_bytes([1, 1, 3]), 65795)
-        

--- a/test/unit/certificate2-tests.py
+++ b/test/unit/certificate2-tests.py
@@ -23,6 +23,7 @@ from rhsm.certificate2 import *
 
 from mock import patch
 
+
 class V1CertTests(unittest.TestCase):
 
     def setUp(self):
@@ -212,6 +213,7 @@ class IdentityCertTests(unittest.TestCase):
         self.assertTrue(isinstance(id_cert, IdentityCertificate))
         self.assertEquals('1.0', str(id_cert.version))
 
+
 class ContentTests(unittest.TestCase):
 
     def test_enabled(self):
@@ -233,6 +235,7 @@ class ContentTests(unittest.TestCase):
                           name="testcontent", label="testcontent", enabled=True)
         self.assertRaises(CertificateException, Content, content_type="",
                           name="testcontent", label="testcontent", enabled=True)
+
 
 class ProductTests(unittest.TestCase):
 

--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -70,7 +70,7 @@ class ExceptionTest(unittest.TestCase):
         self.assertTrue(isinstance("%s" % str(e), basestring))
         self.assertTrue(isinstance("%s" % repr(e), basestring))
 
-    def _create_exception(self,*args, **kwargs):
+    def _create_exception(self, *args, **kwargs):
         return self.exception(args, kwargs)
 
     def _test(self):
@@ -79,6 +79,7 @@ class ExceptionTest(unittest.TestCase):
 
     def test_exception_str(self):
         self._test()
+
 
 # not all our exceptions take a msg arg
 class ExceptionMsgTest(ExceptionTest):

--- a/test/unit/huffman-tests.py
+++ b/test/unit/huffman-tests.py
@@ -21,7 +21,7 @@ class TestHuffmanNode(unittest.TestCase):
         self.node1 = HuffmanNode(1)
         self.node2 = HuffmanNode(2)
         self.parent = HuffmanNode.combine(self.node1, self.node2)
-    
+
     def test_combine(self):
         self.assertEqual(self.parent.weight, 3)
         self.assertEqual(self.parent.left, self.node1)
@@ -30,7 +30,7 @@ class TestHuffmanNode(unittest.TestCase):
         self.assertEqual(self.node2.parent, self.parent)
 
     def test_build_tree(self):
-        leaves = [HuffmanNode(weight) for weight in range(1,5)]
+        leaves = [HuffmanNode(weight) for weight in range(1, 5)]
         root = HuffmanNode.build_tree(leaves)
 
         # assertions based on calculating these by hand

--- a/test/unit/pathtree-tests.py
+++ b/test/unit/pathtree-tests.py
@@ -22,9 +22,10 @@ from rhsm.pathtree import PathTree, PATH_END
 DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                     'entitlement_data.bin')
 
+
 class TestPathTree(unittest.TestCase):
     def test_get_leaf_from_dict(self):
-        codes = {'1010' : 'abc'}
+        codes = {'1010': 'abc'}
         bitstream = '10101111110000'
         ret = PathTree._get_leaf_from_dict(codes, bitstream)
         self.assertEqual(ret, 'abc')
@@ -44,14 +45,14 @@ class TestPathTree(unittest.TestCase):
         bs.bytes = deque([129, 150])
         ret = PathTree._get_node_count(bs)
         self.assertEqual(ret, 150)
-        
+
     def test_get_node_count_big(self):
         bs = GhettoBitStream([])
         # count bigger than 127, need next 2 bytes to represent it
         bs.bytes = deque([130, 1, 17])
         ret = PathTree._get_node_count(bs)
         self.assertEqual(ret, 273)
-        
+
     def test_unpack_data(self):
         data = open(DATA).read()
         nodes, bits = PathTree._unpack_data(data)
@@ -71,7 +72,7 @@ class TestPathTree(unittest.TestCase):
         self.assertEqual(len(ret), 4)
         for node in ret:
             self.assertTrue(isinstance(node, HuffmanNode))
-    
+
     def test_generate_path_tree(self):
         data = open(DATA).read()
         pt = PathTree(data).path_tree

--- a/test/unit/version_tests.py
+++ b/test/unit/version_tests.py
@@ -18,6 +18,7 @@ import unittest
 
 NOT_COLLECTED = "non-collected-package"
 
+
 # NOTE: Because the super class will only initialize version data
 # the first time an instance is created, calling the c'tor with
 # different package data will not reset the data in the new instance.


### PR DESCRIPTION
Fixing pep8 for unit tests.

note: to run unit tests with pep8, "STYLETEST=1" needs to be set
