### PR TITLE
allow python-rhsm to talk to RCS

### DIFF
--- a/test/functional/connection-tests.py
+++ b/test/functional/connection-tests.py
@@ -15,8 +15,9 @@
 
 import unittest
 
-from rhsm.connection import ContentConnection, UEPConnection
 import json
+from rhsm.connection import ContentConnection, UEPConnection, \
+    SpliceConnection, AcceptedException, RemoteServerException
 
 
 class ConnectionTests(unittest.TestCase):
@@ -67,3 +68,50 @@ class HypervisorCheckinTests(unittest.TestCase):
         self.assertEqual(len(response['failedUpdate']), 0)
         self.assertEqual(len(response['updated']), 0)
         self.assertEqual(len(response['created']), 0)
+
+
+class StubRestlib():
+
+    def __init__(self, retcode=None):
+        self.retcode = retcode
+
+    def request_put(self, url=None, params={}):
+        if self.retcode == 202:
+            raise AcceptedException("accepted!")
+        elif self.retcode == 404:
+            raise RemoteServerException(code=404)
+
+
+class StubRhic():
+
+    class StubX509():
+        def as_pem(self):
+            return "PEMPEMPEM"
+
+    def __init__(self, retcode=None):
+        self.x509 = self.StubX509()
+        self.subject = {}
+        self.subject['CN'] = 'CN=ABLOOBLAABLOOO'
+
+
+class SpliceConnectionTests(unittest.TestCase):
+
+    def test_202(self):
+        splice_conn = SpliceConnection(host="127.0.0.1", ssl_port=443, handler='/foo', rhic='/foo/bar',
+                            insecure=True, ca_cert_dir='/baz', rhic_ca_cert='/qux')
+
+        splice_conn.conn = StubRestlib(202)
+
+        with self.assertRaises(AcceptedException):
+            splice_conn.getCerts(identity_cert=StubRhic(), consumer_identifier=None)
+
+    def test_404(self):
+        splice_conn = SpliceConnection(host="127.0.0.1", ssl_port=443, handler='/foo', rhic='/foo/bar',
+                            insecure=True, ca_cert_dir='/baz', rhic_ca_cert='/qux')
+
+        splice_conn.conn = StubRestlib(404)
+
+        with self.assertRaises(RemoteServerException) as rse:
+            splice_conn.getCerts(identity_cert=StubRhic(), consumer_identifier=None)
+
+        self.assertEqual(rse.exception.code, 404)


### PR DESCRIPTION
RCS is a service that returns entitlement certs that are valid for one hour.
The new SpliceConnection class allows subscription-manager to talk to RCS, in
order to retrieve entitlement certs.

This patch is to support changes made in subscription-manager that I didn't make a pull request for yet.. If you want to try out the patch against a real RCS, I can provide a demo machine that's already set up.
