### PR TITLE
772936: Warn the user when clock skew is detected.

### DIFF
--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -18,10 +18,11 @@ import unittest
 
 from rhsm.connection import UEPConnection, Restlib, ConnectionException, ConnectionSetupException, \
         BadCertificateException, RestlibException, GoneException, NetworkException, \
-        RemoteServerException
+        RemoteServerException, drift_check
 
 from mock import Mock
 from datetime import date
+from time import strftime, gmtime
 import simplejson as json
 
 class ConnectionTests(unittest.TestCase):
@@ -140,6 +141,15 @@ class RestlibExceptionTest(ExceptionTest):
         kwargs['code'] = 404
         return self.exception(*args, **kwargs)
 
+
+class DriftTest(unittest.TestCase):
+
+    def test_big_drift(self):
+        self.assertTrue(drift_check("Fri, 14 Dec 3012 19:10:56 GMT", 6))
+
+    def test_no_drift(self):
+        header = strftime("%a, %d %b %Y %H:%M:%S GMT", gmtime())
+        self.assertFalse(drift_check(header))
 
 class GoneExceptionTest(ExceptionTest):
     exception = GoneException


### PR DESCRIPTION
All server responses are required to contain a date header. This
header is used to look for instances where the time on the local machine
is more that 6 hours off of the server. The time is arbitrary.

This should catch cases where the local machine is mis-configured. It is
possible that it will not catch when the candlepin server clock is off
since the header may come from the apache server.
