### PR TITLE
Python-RHSM performance improvements

### DIFF
--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -904,7 +904,7 @@ class OID(object):
             #oid = OID(oid[1:])
             oid = oid[1:]
             parts = self.part[-len(oid):]
-        # Macthing the beginning
+        # Matching the beginning
         elif not oid[-1]:
             #oid = OID(oid[:-1])
             oid = oid[:-1]

--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -530,7 +530,7 @@ class EntitlementCertificate(ProductCertificate):
         valid = False
         for ext_oid, oid_url in self.extensions.iteritems():
             # if this is a download URL
-            if ext_oid.match('2.') and ext_oid.match('.1.6'):
+            if ext_oid.match(OID('2.')) and ext_oid.match(OID('.1.6')):
                 if self._validate_v1_url(oid_url, path):
                     valid = True
                     break

--- a/test/unit/oid-tests.py
+++ b/test/unit/oid-tests.py
@@ -1,0 +1,38 @@
+import unittest
+import os
+
+import certdata
+from rhsm.certificate import OID
+
+from mock import patch
+
+
+class OIDTests(unittest.TestCase):
+
+    def setUp(self):
+        self.oid = OID("1.2.3.4.5.6.7")
+
+    def test_length(self):
+        self.assertEquals(7, len(self.oid))
+
+    def test_match_positive(self):
+        self.assertTrue(self.oid.match(OID("1.2.3.4.5.6.7")))
+        self.assertTrue(self.oid.match(OID("1.")))
+        self.assertTrue(self.oid.match(OID("1.2.3.")))
+        self.assertTrue(self.oid.match(OID("1.*.3.4.5.6.7")))
+        self.assertTrue(self.oid.match(OID("1.*.3.4.*.6.*")))
+        self.assertTrue(self.oid.match(OID(".*")))
+        self.assertTrue(self.oid.match(OID(".5.6.7")))
+        self.assertTrue(self.oid.match(OID(".7")))
+
+    def test_match_negative(self):
+        self.assertFalse(self.oid.match(OID("1.2.3.4.5.9.7")))
+        self.assertFalse(self.oid.match(OID("1.2.4.")))
+        self.assertFalse(self.oid.match(OID("1.*.4.")))
+        # * matches only one item
+        self.assertFalse(self.oid.match(OID("1.*")))
+
+        # Not an OID
+        self.assertFalse(self.oid.match("1.2.3.4.5.6.7"))
+
+


### PR DESCRIPTION
The RHOS os folks were seeing performance issues in the client using the employee SKU. This pull request goes after the low hanging fruit of making the OID reading a bit more performant. Even though each tweak is small, a single call to list --available would cause 100K + calls on some of these methods so little items add up

Next up would be to be a bit smarter on how to read the oids from content sets. This could be laissez-faire initializing the content sets.
