### PR TITLE
907536: Don't send body if it's just ""

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -426,7 +426,6 @@ class Restlib(object):
                 if not id_cert.is_valid():
                     raise ExpiredIdentityCertException()
             raise e
-
         response = conn.getresponse()
         result = {
             "content": response.read(),
@@ -481,13 +480,13 @@ class Restlib(object):
     def request_get(self, method):
         return self._request("GET", method)
 
-    def request_post(self, method, params=""):
+    def request_post(self, method, params=None):
         return self._request("POST", method, params)
 
     def request_head(self, method):
         return self._request("HEAD", method)
 
-    def request_put(self, method, params=""):
+    def request_put(self, method, params=None):
         return self._request("PUT", method, params)
 
     def request_delete(self, method):


### PR DESCRIPTION
We default post and put's to a body of "". Restlib._request
ends up making the body of the message be the jsonified
'""' instead of just empty with 0 content length.

Candlepin doesn't have a problem with this, but old
version of headpin do. Change default body to None, so
we use that in the cases where we don't send anything
in the POST/PUT body.
