### PR TITLE
The package gcc is required to build from source.

### DIFF
--- a/python-rhsm.spec
+++ b/python-rhsm.spec
@@ -25,6 +25,7 @@ Requires: python-simplejson
 Requires: python-iniparse
 Requires: rpm-python
 
+BuildRequires: gcc
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
 BuildRequires: openssl-devel


### PR DESCRIPTION
On a fresh F18 machine, tito build errors out because the gcc
command was not found. Running yum install gcc fixed this.
