### PR TITLE
support for two new candlepin API methods

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -846,7 +846,7 @@ class UEPConnection:
         method = "/consumers/%s/entitlements" % self.sanitize(consumerId)
         return self.conn.request_delete(method)
 
-    def checkin(self, consumerId, checkin_date=None ):
+    def checkin(self, consumerId, checkin_date=None):
         method = "/consumers/%s/checkin" % self.sanitize(consumerId)
         # add the optional date to the url
         if checkin_date:


### PR DESCRIPTION
This patch allows access to the new API in candlepin that allows a user to set
the last checkin time for a consumer. Additionally, there is a new method for
finding all consumers, and an additional argument for specifying a uuid when
creating a consumer.
