### PR TITLE
replacing instances of // with / before path checking

### DIFF
--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -17,6 +17,7 @@ import zlib
 import logging
 import os
 import base64
+import posixpath
 import re
 import simplejson as json
 
@@ -521,6 +522,7 @@ class EntitlementCertificate(ProductCertificate):
 
         :raise:    ValueError when self.version.major < 3
         """
+        path = posixpath.normpath(path)
         if self.version.major < 3:
             return self._check_v1_path(path)
         else:

--- a/test/unit/certificate2-tests.py
+++ b/test/unit/certificate2-tests.py
@@ -87,6 +87,7 @@ class V1CertTests(unittest.TestCase):
         self.assertTrue(self.ent_cert.check_path('/foo/path/never'))
         self.assertTrue(self.ent_cert.check_path('/foo/path/never/'))
         self.assertTrue(self.ent_cert.check_path('/foo/path/never/bar/a/b/c'))
+        self.assertTrue(self.ent_cert.check_path('/foo/path/never/bar//a/b/c'))
 
     def test_check_path_with_var(self):
         # matches /path/to/$basearch/$releasever/awesomeos
@@ -194,6 +195,7 @@ class V3CertTests(unittest.TestCase):
 
     def test_match_path(self):
         self.assertTrue(self.ent_cert.check_path('/path/to/awesomeos/x86_64'))
+        self.assertTrue(self.ent_cert.check_path('/path/to/awesomeos//x86_64'))
 
     def test_match_deep_path(self):
         self.assertTrue(self.ent_cert.check_path('/path/to/awesomeos/x86_64/foo/bar'))


### PR DESCRIPTION
The path verification logic with certificates prior to v3 would treat the urls  /foo/bar/  and /foo//bar/ as the same.  i.e. It would treat double forward slashes as one.  The v3 logic does not do this and will not validate that /foo//bar/ matches /foo/bar/.

To validate this, simply run the tests with my two added assertions.  The v3 one will fail, the v2 one will pass.  

This commit does a manual replace of // with / in the path before any validation.  I can see an argument for putting this within the path_tree code since the pre-v3 cert code already handles this fine, but I think it also makes sense (and is simpler) to do this prior to passing to either equality checks.  
