### PR TITLE
Alikins/flex branding

### DIFF
--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -1056,7 +1056,7 @@ class Product:
         self.version = self.ext.get('2')
         self.arch = self.ext.get('3')
         self.provided_tags = parse_tags(self.ext.get('4'))
-        self.os = self.ext.get('5')
+        self.brand_type = self.ext.get('5')
 
     def getHash(self):
         return self.hash
@@ -1073,8 +1073,8 @@ class Product:
     def getProvidedTags(self):
         return self.provided_tags
 
-    def getOs(self):
-        return self.os
+    def getBrandType(self):
+        return self.brand_type
 
     def __eq__(self, rhs):
         return (self.getHash() == rhs.getHash())
@@ -1087,7 +1087,7 @@ class Product:
         s.append('\tVersion ...... = %s' % self.getVersion())
         s.append('\tArchitecture . = %s' % self.getArch())
         s.append('\tProvided Tags  = %s' % self.getProvidedTags())
-        s.append('\tIs OS        = %s' % self.getOs())
+        s.append('\tBrand Type     = %s' % self.getBrandType())
         s.append('}')
         return '\n'.join(s)
 

--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -185,7 +185,7 @@ class _CertFactory(object):
                 version=ext.get('2'),
                 architectures=ext.get('3'),
                 provided_tags=parse_tags(ext.get('4')),
-                os=ext.get('5')
+                brand_type=ext.get('5')
                 ))
         return products
 
@@ -323,7 +323,7 @@ class _CertFactory(object):
                 name=product['name'],
                 version=product.get('version', None),
                 architectures=product.get('architectures', []),
-                os=product.get('os', None)
+                brand_type=product.get('brand_type', None)
                 ))
             # TODO: skipping provided tags here, we don't yet generate
             # v3 product certs, we may never, which is the only place provided
@@ -614,7 +614,7 @@ class Product(object):
     Represents the product information from a certificate.
     """
     def __init__(self, id=None, name=None, version=None, architectures=None,
-            provided_tags=None, os=None):
+            provided_tags=None, brand_type=None):
 
         if name is None:
             raise CertificateException("Product missing name")
@@ -637,7 +637,7 @@ class Product(object):
         if self.provided_tags is None:
             self.provided_tags = []
 
-        self.os = os
+        self.brand_type = brand_type
 
     def __eq__(self, other):
         return (self.id == other.id)

--- a/test/unit/certificate2-tests.py
+++ b/test/unit/certificate2-tests.py
@@ -37,13 +37,13 @@ class V1ProductCertTests(unittest.TestCase):
         self.assertEquals('100000000000002', self.prod_cert.subject['CN'])
 
     def test_os_old_cert(self):
-        self.assertTrue(self.prod_cert.products[0].os is None)
+        self.assertTrue(self.prod_cert.products[0].brand_type is None)
 
-    def test_set_os(self):
-        os = "OS"
+    def test_set_brand_type(self):
+        brand_type = "OS"
 
-        self.prod_cert.products[0].os = os
-        self.assertEquals(os, self.prod_cert.products[0].os)
+        self.prod_cert.products[0].brand_type = brand_type
+        self.assertEquals(brand_type, self.prod_cert.products[0].brand_type)
 
 
 class V1EntCertTests(unittest.TestCase):
@@ -325,16 +325,16 @@ class ProductTests(unittest.TestCase):
         self.assertTrue(p.architectures is not None)
         self.assertTrue(isinstance(p.architectures, list))
 
-    def test_no_os(self):
+    def test_no_brand_type(self):
         p = Product(id="pid", name="pname")
-        self.assertTrue(p.os is None)
+        self.assertTrue(p.brand_type is None)
 
-    def test_os(self):
+    def test_brand_type(self):
         p = Product(id="pid", name="pname",
-                    os="pos")
-        self.assertTrue(p.os == "pos")
+                    brand_type="pbrand_type")
+        self.assertTrue(p.brand_type == "pbrand_type")
 
-    def test_os_none(self):
+    def test_brand_type_none(self):
         p = Product(id="pid", name="pname",
-                    os=None)
-        self.assertTrue(p.os is None)
+                    brand_type=None)
+        self.assertTrue(p.brand_type is None)


### PR DESCRIPTION
For use with subscription-manager flex branding changes.

Needs flex_branding branch of candlepin to get certs with this populated.
