### PR TITLE
1000145: Fix deprecated exception message warning.

### DIFF
--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -96,7 +96,8 @@ class _CertFactory(object):
         except CertificateException, e:
             raise e
         except Exception, e:
-            raise CertificateException(e.message)
+            log.exception(e)
+            raise CertificateException(str(e))
 
     def _create_v1_cert(self, version, extensions, x509, path):
 


### PR DESCRIPTION
Base exception message has been deprecated since Python 2.6.
