### PR TITLE
800732: Remove depdendency on simplejson.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ rpmlint:
 
 versionlint:
 	@TMPFILE=`mktemp` || exit 1; \
-	pyqver2.py -m 2.5 -v  $(STYLEFILES) | tee $$TMPFILE; \
+	pyqver2.py -m 2.7 -v  $(STYLEFILES) | tee $$TMPFILE; \
 	! test -s $$TMPFILE
 
 

--- a/python-rhsm.spec
+++ b/python-rhsm.spec
@@ -21,7 +21,6 @@ URL: http://fedorahosted.org/candlepin
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Requires: m2crypto
-Requires: python-simplejson
 Requires: python-iniparse
 Requires: rpm-python
 

--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -18,7 +18,7 @@ import logging
 import os
 import posixpath
 import re
-import simplejson as json
+import json
 import zlib
 
 log = logging.getLogger(__name__)

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -20,7 +20,7 @@ import datetime
 import locale
 import logging
 import os
-import simplejson as json
+import json
 import socket
 import sys
 import time

--- a/src/rhsm/profile.py
+++ b/src/rhsm/profile.py
@@ -11,7 +11,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 #
 import logging
-import simplejson as json
+import json
 
 import rpm
 

--- a/test/functional/connection-tests.py
+++ b/test/functional/connection-tests.py
@@ -17,7 +17,7 @@ import unittest
 
 from rhsm.connection import ContentConnection, UEPConnection, drift_check, Restlib,\
     UnauthorizedException, ForbiddenException, AuthenticationException, RestlibException
-import simplejson as json
+import json
 import mock
 
 

--- a/test/functional/profile-tests.py
+++ b/test/functional/profile-tests.py
@@ -15,7 +15,7 @@ import unittest
 
 from rhsm.profile import Package, RPMProfile, get_profile, InvalidProfileType
 from mock import Mock
-import simplejson as json
+import json
 
 
 class ProfileTests(unittest.TestCase):

--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -24,7 +24,7 @@ from rhsm.connection import UEPConnection, Restlib, ConnectionException, Connect
 from mock import Mock
 from datetime import date
 from time import strftime, gmtime
-import simplejson as json
+import json
 
 
 class ConnectionTests(unittest.TestCase):


### PR DESCRIPTION
All import statements use json now. The spec file requires was removed, the the version check was bumped to 2.7 so that we run on 2.6 or higher.
