### PR TITLE
1008808: json ValueErrors have no .msg attribute

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -492,7 +492,7 @@ class Restlib(object):
                     parsed = json.loads(response['content'], object_hook=self._decode_dict)
                 except ValueError, e:
                     log.error("Response: %s" % response['status'])
-                    log.error("JSON parsing error: %s" % e.msg)
+                    log.error("JSON parsing error: %s" % e)
                 except Exception, e:
                     log.error("Response: %s" % response['status'])
                     log.exception(e)


### PR DESCRIPTION
In cases where we expect a json body on an error
response, we try to parse it, and catch any exceptions
if it's not valid and ignore. Except we were attempting
to log the ValueError.msg, which doesn't exist, raising
an AttributeError.
