### PR TITLE
[dont merge yet] trims guest objects for old servers

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -766,7 +766,7 @@ class UEPConnection:
         if installed_products is not None:
             params['installedProducts'] = installed_products
         if guest_uuids is not None:
-            params['guestIds'] = guest_uuids
+            params['guestIds'] = self._sanitize_guests(guest_uuids)
         if facts is not None:
             params['facts'] = facts
         if release is not None:
@@ -783,6 +783,19 @@ class UEPConnection:
         method = "/consumers/%s" % self.sanitize(uuid)
         ret = self.conn.request_put(method, params)
         return ret
+
+    def _sanitize_guests(self, guest_uuids):
+        """
+        Old servers don't support overloading some objects.  We
+        need to make sure we can upload additional guestId data
+        before we send a json object, otherwise we send a list
+        the old way.
+        """
+        if len(guest_uuids) and \
+                not isinstance(guest_uuids[0], basestring) and \
+                not self.supports_resource("guest_limit"):
+            return [guest['guestId'] for guest in guest_uuids]
+        return guest_uuids
 
     def updatePackageProfile(self, consumer_uuid, pkg_dicts):
         """

--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -61,6 +61,22 @@ class ConnectionTests(unittest.TestCase):
     def test_clean_up_prefix(self):
         self.assertTrue(self.cp.handler == "/Test")
 
+    def test_update_consumer_guest_ids_old_cp(self):
+        self.cp.conn = Mock()
+        self.cp.conn.request_get = Mock(return_value=[])
+        result = self.cp._sanitize_guests([{'guestId': 'a', 'active': True},
+                {'guestId': 'b', 'active': True}])
+        self.assertEquals(['a', 'b'], result)
+
+    def test_update_consumer_guest_ids_new_cp(self):
+        self.cp.conn = Mock()
+        self.cp.conn.request_get = Mock(return_value=[{'rel': 'guest_limit',
+            'href': '/href/guestid'}])
+        guest_objects = [{'guestId': 'a', 'active': True},
+                {'guestId': 'b', 'active': True}]
+        result = self.cp._sanitize_guests(guest_objects)
+        self.assertEquals(guest_objects, result)
+
 
 class RestlibValidateResponseTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Waiting on candlepin pr ckozak/virt_limit to get in

This will require less work inside of virt-who.
added testing for _sanitize_guests
