### PR TITLE
Detect when operating in container mode and load host system's config.

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -16,12 +16,16 @@
 # in this software or its documentation.
 #
 
+import os
 from iniparse import SafeConfigParser
 from iniparse.compat import NoOptionError, InterpolationMissingOptionError, \
         NoSectionError
 import re
 
+CONFIG_ENV_VAR = "RHSM_CONFIG"
+
 DEFAULT_CONFIG_DIR = "/etc/rhsm"
+HOST_CONFIG_DIR = "/etc/rhsm-host" # symlink inside docker containers
 DEFAULT_CONFIG_PATH = "%s/rhsm.conf" % DEFAULT_CONFIG_DIR
 DEFAULT_PROXY_PORT = "3128"
 
@@ -36,6 +40,9 @@ DEFAULT_CDN_PORT = "443"
 DEFAULT_CDN_PREFIX = "/"
 
 DEFAULT_CA_CERT_DIR = '/etc/rhsm/ca/'
+
+DEFAULT_ENT_CERT_DIR = '/etc/pki/entitlement'
+HOST_ENT_CERT_DIR = '/etc/pki/entitlement-host'
 
 SERVER_DEFAULTS = {
         'hostname': DEFAULT_HOSTNAME,
@@ -53,7 +60,7 @@ RHSM_DEFAULTS = {
         'ca_cert_dir': DEFAULT_CA_CERT_DIR,
         'repo_ca_cert': DEFAULT_CA_CERT_DIR + 'redhat-uep.pem',
         'productcertdir': '/etc/pki/product',
-        'entitlementcertdir': '/etc/pki/entitlement',
+        'entitlementcertdir': DEFAULT_ENT_CERT_DIR,
         'consumercertdir': '/etc/pki/consumer',
         'manage_repos': '1',
         'full_refresh_on_yum': '0',
@@ -205,8 +212,65 @@ class RhsmConfigParser(SafeConfigParser):
         return None
 
 
+class RhsmHostConfigParser(RhsmConfigParser):
+    """
+    Sub-class of config parser automatically loaded when we detect that
+    we're running in a container environment.
+
+    Host config is shared with containers as /etc/rhsm-host. However the
+    rhsm.conf within will still be referencing /etc/rhsm for a couple
+    properties. (ca_cert_dir, repo_ca_cert)
+
+    Instead we load config file normally, and assume to replace occurrences
+    of /etc/rhsm with /etc/rhsm-host in these properties.
+
+    A similar adjustment is necessary for /etc/pki/entitlement-host if
+    present.
+    """
+    def __init__(self, config_file=None, defaults=None):
+        RhsmConfigParser.__init__(self, config_file, defaults)
+
+        # Override the ca_cert_dir and repo_ca_cert if necessary:
+        ca_cert_dir = self.get('rhsm', 'ca_cert_dir')
+        repo_ca_cert = self.get('rhsm', 'repo_ca_cert')
+        ca_cert_dir = ca_cert_dir.replace(DEFAULT_CONFIG_DIR, HOST_CONFIG_DIR)
+        repo_ca_cert = repo_ca_cert.replace(DEFAULT_CONFIG_DIR, HOST_CONFIG_DIR)
+        self.set('rhsm', 'ca_cert_dir', ca_cert_dir)
+        self.set('rhsm', 'repo_ca_cert', repo_ca_cert)
+
+        # Similarly if /etc/pki/entitlement-host exists, override this too.
+        # If for some reason the host config is pointing to another directory
+        # we leave the config setting alone, our tooling isn't going to be
+        # able to handle it anyhow.
+        if os.path.exists(HOST_ENT_CERT_DIR):
+            ent_cert_dir = self.get('rhsm', 'entitlementcertdir')
+            ent_cert_dir = ent_cert_dir.replace(DEFAULT_ENT_CERT_DIR,
+                HOST_ENT_CERT_DIR)
+            self.set('rhsm', 'entitlementcertdir', ent_cert_dir)
+
+
+def in_container():
+    """
+    Are we running in a docker container or not?
+
+    Assumes that if we see host rhsm configuration shared with us, we must
+    be running in a container.
+    """
+    if os.path.exists(HOST_CONFIG_DIR):
+        return True
+    return False
+
+
 def initConfig(config_file=None):
-    """get an rhsm config instance"""
+    """
+    Get an rhsm config instance.
+
+    Will use the first config file defined in the following list:
+
+    - argument to this method if provided (only for tests)
+    - /etc/rhsm-host/rhsm.conf if it exists (only in containers)
+    - /etc/rhsm/rhsm.conf
+    """
     global CFG
     # If a config file was specified, assume we should overwrite the global config
     # to use it. This should only be used in testing. Could be switch to env var?
@@ -214,12 +278,18 @@ def initConfig(config_file=None):
         CFG = RhsmConfigParser(config_file=config_file)
         return CFG
 
-    # Normal application behavior, just read the default file if we haven't
-    # already:
     try:
         CFG = CFG
     except NameError:
         CFG = None
     if CFG is None:
-        CFG = RhsmConfigParser(config_file=DEFAULT_CONFIG_PATH)
+
+        # Load alternate config file implementation if we detect that we're
+        # running in a container.
+        if in_container():
+            CFG = RhsmHostConfigParser(
+                config_file=os.path.join(HOST_CONFIG_DIR, 'rhsm.conf'))
+        else:
+            CFG = RhsmConfigParser(config_file=DEFAULT_CONFIG_PATH)
+
     return CFG


### PR DESCRIPTION
With the end goal of being able to generate correct redhat.repo for a
container, we need a way to access the host's /etc/rhsm configuration in as
futureproof a way as possible. (as this may change) To accommodate this we
check for existence of a (presumably) symlink at /etc/rhsm-host, and if found,
we assume we're operating inside a container and load the host's config. The
symlink allows for possibility of the actual location of host's config
changing, and _not_ re-using /etc/rhsm/ helps prevent any complications with
rpm's and file ownership. (as /etc/rhsm is owned by our packages)

However there is an additional problem with the contents of rhsm.conf, while it
may live at /etc/rhsm-host in container mode, it still contains two properties
referencing full paths under /etc/rhsm for ca certificates and the CDN cert. We
need the hosts values in a Satellite use-case, so these must be adjusted.

To accommodate this we check if we're in container mode, and if so load a
config sub-class which replaces /etc/rhsm with /etc/rhsm-host in these values,
if it looks like we should.

A similar replacement will be done for entitlement directory at
/etc/pki/entitlement-host for the same reasons.

(dgoodwin@lenovo {dgoodwin/host-config} ~/src/python-rhsm) $ cat test.py           
# !/usr/bin/python

from rhsm.config import initConfig

c = initConfig()
print c
print "ca_cert_dir = %s" % c.get('rhsm', 'ca_cert_dir')
print "repo_ca_cert = %s" % c.get('rhsm', 'repo_ca_cert')
print "entitlementcertdir = %s" % c.get('rhsm', 'entitlementcertdir')
(dgoodwin@lenovo {dgoodwin/host-config} ~/src/python-rhsm) $ python test.py  
<rhsm.config.RhsmConfigParser object at 0x7f359e9f8ad0>
ca_cert_dir = /etc/rhsm/ca/
repo_ca_cert = /etc/rhsm/ca/candlepin-local.pem
entitlementcertdir = /etc/pki/entitlement
(dgoodwin@lenovo {dgoodwin/host-config} ~/src/python-rhsm) $ sudo ln -s /etc/rhsm /etc/rhsm-host
(dgoodwin@lenovo {dgoodwin/host-config} ~/src/python-rhsm) $ python test.py  
<rhsm.config.RhsmHostConfigParser object at 0x7fcaa559bad0>
ca_cert_dir = /etc/rhsm-host/ca/
repo_ca_cert = /etc/rhsm-host/ca/candlepin-local.pem
entitlementcertdir = /etc/pki/entitlement-host
(dgoodwin@lenovo {dgoodwin/host-config} ~/src/python-rhsm) $ 

![rdmjks0](https://cloud.githubusercontent.com/assets/51265/3216630/1c05d81a-efd5-11e3-8bb1-251d72bbbab8.gif)
