### PR TITLE
Add a key_path() to EntitlementCertificate

### DIFF
--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -610,8 +610,23 @@ class EntitlementCertificate(ProductCertificate):
 
         # Can assume we have a path here, super method would have thrown
         # Exception if we didn't:
-        key_path = self.path.replace(".pem", "-key.pem")
+        key_path = self.key_path()
         os.unlink(key_path)
+
+    def key_path(self):
+        """
+        Returns the full path to the cert key's pem.
+        """
+        dir_path, cert_filename = os.path.split(self.path)
+        try:
+            key_filename = "%s-key.%s" % tuple(cert_filename.rsplit(".", 1))
+        except TypeError, e:
+            log.exception(e)
+            raise CertificateException("Entitlement certificate path \"%s\" is not in "
+                                       "in the expected format so the key file path "
+                                       "could not be based on it." % self.path)
+        key_path = os.path.join(dir_path, key_filename)
+        return key_path
 
 
 class Product(object):

--- a/test/unit/certificate2-tests.py
+++ b/test/unit/certificate2-tests.py
@@ -243,6 +243,46 @@ class V3_2CertTests(unittest.TestCase):
                 self.ent_cert.pool.id)
 
 
+class TestEntCertV1KeyPath(unittest.TestCase):
+    cert_data = certdata.ENTITLEMENT_CERT_V1_0
+
+    def setUp(self):
+        self.ent_cert = create_from_pem(self.cert_data)
+
+    def test_key_path(self):
+        self.ent_cert.path = "/etc/pki/entitlement/12345.pem"
+        expected_key_path = "/etc/pki/entitlement/12345-key.pem"
+
+        actual_key_path = self.ent_cert.key_path()
+        self.assertEquals(actual_key_path, expected_key_path)
+
+    def test_key_path_extra_pem(self):
+        self.ent_cert.path = "/etc/pki/entitlement/12345-with-a.pem-in-the-name.pem"
+        expected_key_path = "/etc/pki/entitlement/12345-with-a.pem-in-the-name-key.pem"
+
+        actual_key_path = self.ent_cert.key_path()
+        self.assertEquals(actual_key_path, expected_key_path)
+
+    def test_key_path_no_pem(self):
+        self.ent_cert.path = "/etc/pki/entitlement/12345"
+        self.assertRaises(CertificateException, self.ent_cert.key_path)
+
+    def test_key_path_no_slash(self):
+        self.ent_cert.path = "12345.pem"
+        expected_key_path = "12345-key.pem"
+
+        actual_key_path = self.ent_cert.key_path()
+        self.assertEquals(actual_key_path, expected_key_path)
+
+
+class TestEntCertV3_0KeyPath(TestEntCertV1KeyPath):
+    cert_data = certdata.ENTITLEMENT_CERT_V3_0
+
+
+class TestEntCertV3_2KeyPath(TestEntCertV1KeyPath):
+    cert_data = certdata.ENTITLEMENT_CERT_V3_2
+
+
 class V3_2ContentArchCertTests(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Returns the key file path based on the certs path.

Assumes name is of the format '/some/path/*.pem'
