### PR TITLE
Add crypto library to the linker arguments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     include_package_data = True,
 
     ext_modules=[Extension('rhsm._certificate', ['src/certificate.c'],
-                           libraries=['ssl'], extra_link_args=['-lcrypto'])],
+                           libraries=['ssl', 'crypto'])],
 
     test_suite = 'nose.collector',
 


### PR DESCRIPTION
Add crypto library to linker arguments to that if python-rhsm is installed directly from github all of the symbols resolve properly.  Without this argument errors such as the following occur when using the certificate object.  
/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/rhsm/_certificate.so: undefined symbol: ASN1_OCTET_STRING_it
