### PR TITLE
Add libcrypto to list of libs to link to.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     include_package_data = True,
 
     ext_modules=[Extension('rhsm._certificate', ['src/certificate.c'],
-                           libraries=['ssl'])],
+                           libraries=['ssl', 'crypto'])],
 
     test_suite = 'nose.collector',
 


### PR DESCRIPTION
Before this change, Pulp was getting "undefined symbol: ASN1_OCTET_STRING_it"
in their CI environment.
