### PR TITLE
1120431: Support for complex path matching.

### DIFF
--- a/src/rhsm/pathtree.py
+++ b/src/rhsm/pathtree.py
@@ -96,12 +96,17 @@ class PathTree(object):
             # we hit the end of a path in the tree, so the match was successful
             return True
         if words:
+            words_to_try = []
+            # Look fo an exact match
             if words[0] in tree:
-                words_to_try = [words[0]]
-            else:
-                # we allow any word to match against entitlement variables
-                # such as "$releasever".
-                words_to_try = [word for word in tree.keys() if word.startswith('$')]
+                words_to_try.append(words[0])
+
+            # we allow any word to match against entitlement variables
+            # such as "$releasever".
+            for word in tree.keys():
+                if word.startswith('$'):
+                    words_to_try.append(word)
+
             for word in words_to_try:
                 # keep trying for each child
                 for child in tree[word]:

--- a/test/unit/pathtree-tests.py
+++ b/test/unit/pathtree-tests.py
@@ -99,3 +99,44 @@ class TestPathTree(unittest.TestCase):
         pt.path_tree = tree
         self.assertTrue(pt.match_path('/foo/path/bar'))
         self.assertFalse(pt.match_path('/foo/path/abc'))
+
+    def test_match_first_variable(self):
+        tree = {'$anything': [{'$releasever': [{'bar':[{PATH_END: None}]}]}]}
+        data = open(DATA).read()
+        pt = PathTree(data)
+        # just swap out the pre-cooked data with out with
+        pt.path_tree = tree
+        self.assertTrue(pt.match_path('/foo/path/bar'))
+        self.assertFalse(pt.match_path('/foo/path/abc'))
+
+    def test_match_last_variable(self):
+        tree = {'foo': [{'$releasever': [{'$bar':[{PATH_END: None}]}]}]}
+        data = open(DATA).read()
+        pt = PathTree(data)
+        # just swap out the pre-cooked data with out with
+        pt.path_tree = tree
+        self.assertTrue(pt.match_path('/foo/path/bar'))
+        self.assertTrue(pt.match_path('/foo/path/abc'))
+        self.assertFalse(pt.match_path('/boo/path/abc'))
+
+    def test_match_different_variables(self):
+        tree1 = {'foo': [{'$releasever': [{'bar':[{PATH_END: None}]}],
+                         'jarjar': [{'binks':[{PATH_END: None}]}]}]}
+        tree2 = {'foo': [{'jarjar': [{'binks':[{PATH_END: None}]}],
+                         '$releasever': [{'bar':[{PATH_END: None}]}]}]}
+        tree3 = {'foo': [{'$releasever': [{'bar':[{PATH_END: None}]}]},
+                         {'jarjar': [{'binks':[{PATH_END: None}]}]}]}
+        tree4 = {'foo': [{'jarjar': [{'binks':[{PATH_END: None}]}]},
+                         {'$releasever': [{'bar':[{PATH_END: None}]}]}]}
+        trees = [tree1, tree2, tree3, tree4]
+        data = open(DATA).read()
+        pt = PathTree(data)
+        #just swap out the pre-cooked data with out with
+        for tree in trees:
+            pt.path_tree = tree
+            self.assertTrue(pt.match_path('/foo/path/bar'))
+            self.assertFalse(pt.match_path('/foo/path/abc'))
+            self.assertFalse(pt.match_path('/foo/path/abc'))
+            self.assertTrue(pt.match_path('/foo/jarjar/binks'))
+            self.assertTrue(pt.match_path('/foo/jarjar/bar'))
+            self.assertFalse(pt.match_path('/foo/jarjar/notbinks'))


### PR DESCRIPTION
RHUI is using this code server side. It was having issues matching paths such as
/one/$release/two
/one/three/four

with the strings

/one/three/two

The issue was that the old algorithm would look at the second node, match the three, and
not use the wildcard of the $release. The new alogithm fixes this.
