### PR TITLE
Set CA PEM files permissions to 644.

### DIFF
--- a/python-rhsm.spec
+++ b/python-rhsm.spec
@@ -68,7 +68,7 @@ rm -rf %{buildroot}
 
 %{python_sitearch}/rhsm/*
 %{python_sitearch}/rhsm-*.egg-info
-%attr(640,root,root) %{_sysconfdir}/rhsm/ca/*.pem
+%attr(644,root,root) %{_sysconfdir}/rhsm/ca/*.pem
 
 %changelog
 * Fri Oct 03 2014 Alex Wood <awood@redhat.com> 1.13.3-1


### PR DESCRIPTION
There is nothing secret in the CA files.  It's just the server
certificate.  Having them as 640 just makes life annoying for testing.
