### PR TITLE
Do not process proxy environment variables if host is in no_proxy

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -268,8 +268,14 @@ class ContentConnection(object):
         self.timeout_altered = False
 
         # get the proxy information from the environment variable
-        # if available
-        info = get_env_proxy_info()
+        # if available and host is not in no_proxy
+        if urllib.proxy_bypass_environment(self.host):
+            info = {'proxy_username': '',
+                   'proxy_hostname': '',
+                   'proxy_port': '',
+                   'proxy_password': ''}
+        else:
+            info = get_env_proxy_info()
 
         self.proxy_hostname = proxy_hostname or config.get('server', 'proxy_hostname') or info['proxy_hostname']
         self.proxy_port = proxy_port or config.get('server', 'proxy_port') or info['proxy_port']
@@ -651,8 +657,14 @@ class UEPConnection:
         self.handler = self.handler.rstrip("/")
 
         # get the proxy information from the environment variable
-        # if available
-        info = get_env_proxy_info()
+        # if available and host is not in no_proxy
+        if urllib.proxy_bypass_environment(self.host):
+            info = {'proxy_username': '',
+                   'proxy_hostname': '',
+                   'proxy_port': '',
+                   'proxy_password': ''}
+        else:
+            info = get_env_proxy_info()
 
         self.proxy_hostname = proxy_hostname or config.get('server', 'proxy_hostname') or info['proxy_hostname']
         self.proxy_port = proxy_port or config.get('server', 'proxy_port') or info['proxy_port']


### PR DESCRIPTION
Subscription-manager reads proxy configuration from the environment variables if not specified elsewhere but does not respect the no_proxy environment variable. This can be solved with urllib.proxy_bypass_environment()