### PR TITLE
1225600: Default config entry needs to include the substitution string

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -58,7 +58,7 @@ SERVER_DEFAULTS = {
 RHSM_DEFAULTS = {
         'baseurl': 'https://' + DEFAULT_CDN_HOSTNAME,
         'ca_cert_dir': DEFAULT_CA_CERT_DIR,
-        'repo_ca_cert': DEFAULT_CA_CERT_DIR + 'redhat-uep.pem',
+        'repo_ca_cert': '%(ca_cert_dir)sredhat-uep.pem',
         'productcertdir': '/etc/pki/product',
         'entitlementcertdir': DEFAULT_ENT_CERT_DIR,
         'consumercertdir': '/etc/pki/consumer',


### PR DESCRIPTION
Otheriwse setting it back to default repo_ca_cert value will lock the
directory to the current ca_cert_dir