### PR TITLE
Move Python.h include to be first include

### DIFF
--- a/src/certificate.c
+++ b/src/certificate.c
@@ -41,13 +41,14 @@
  * Thus, we write our own binding!
  */
 
+#include "Python.h"
+
 #include <openssl/asn1.h>
 #include <openssl/asn1t.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
-#include "Python.h"
 #include "structmember.h"
 
 #define MAX_BUF 256


### PR DESCRIPTION
This quiets the compiler warnings about
redefining POSIX_C_SOURCE.

This is the suggested fix from
https://docs.python.org/2/c-api/intro.html#include-files
mentioned in https://bugzilla.redhat.com/show_bug.cgi?id=518385
