### PR TITLE
Add user-agent to rhsm requests.

### DIFF
--- a/src/rhsm/utils.py
+++ b/src/rhsm/utils.py
@@ -17,6 +17,7 @@ import gettext
 import os
 import re
 from urlparse import urlparse
+
 from rhsm.config import DEFAULT_PROXY_PORT
 
 _ = lambda x: gettext.ldgettext("rhsm", x)
@@ -232,3 +233,24 @@ def get_env_proxy_info():
         else:
             the_proxy['proxy_port'] = int(info[3])
     return the_proxy
+
+
+def cmd_name(argv):
+    """Attempt to get a meaningful command name from argv.
+
+    This handles cases where argv[0] isn't helpful (for
+    example, '/usr/bin/python' or '__main__.py'.
+    """
+    argv0 = os.path.basename(argv[0])
+    argvdir = os.path.dirname(argv[0])
+    head, tail = os.path.split(argvdir)
+
+    cmd_name_string = argv0
+    # initial-setup is launched as 'python -m initial_setup', so
+    # sys.argv looks like
+    # ['/usr/lib/python2.7/site-packages/initial_setup/__main__.py'],
+    # so we look for initial_setup in the exe path.
+    if tail == "initial_setup":
+        cmd_name_string = "initial-setup"
+
+    return cmd_name_string

--- a/test/unit/util-tests.py
+++ b/test/unit/util-tests.py
@@ -6,7 +6,7 @@ from rhsm.utils import remove_scheme, get_env_proxy_info, \
     ServerUrlParseErrorEmpty, ServerUrlParseErrorNone, \
     ServerUrlParseErrorPort, ServerUrlParseErrorScheme, \
     ServerUrlParseErrorJustScheme, has_bad_scheme, has_good_scheme, \
-    parse_url
+    parse_url, cmd_name
 from rhsm.config import DEFAULT_PORT, DEFAULT_PREFIX, DEFAULT_HOSTNAME, \
     DEFAULT_CDN_HOSTNAME, DEFAULT_CDN_PORT, DEFAULT_CDN_PREFIX
 
@@ -379,3 +379,45 @@ class TestProxyInfo(unittest.TestCase):
             self.assertEquals(None, proxy_info["proxy_password"])
             self.assertEquals("host", proxy_info["proxy_hostname"])
             self.assertEquals(int("1111"), proxy_info["proxy_port"])
+
+
+class TestCmdName(unittest.TestCase):
+    def test_usr_sbin(self):
+        argv = ['/usr/sbin/subscription-manager', 'list']
+        self.assertEquals("subscription-manager", cmd_name(argv))
+
+    def test_bin(self):
+        argv = ['bin/subscription-manager', 'subscribe', '--auto']
+        self.assertEquals("subscription-manager", cmd_name(argv))
+
+    def test_sbin(self):
+        argv = ['/sbin/subscription-manager', 'list']
+        self.assertEquals("subscription-manager", cmd_name(argv))
+
+    def test_subscription_manager_gui(self):
+        argv = ['/sbin/subscription-manager-gui']
+        self.assertEquals("subscription-manager-gui", cmd_name(argv))
+
+    def test_initial_setup(self):
+        argv = ['/usr/lib/python2.7/site-packages/initial_setup/__main__.py']
+        self.assertEquals("initial-setup", cmd_name(argv))
+
+    def test_yum(self):
+        argv = ['/bin/yum', 'install', 'zsh']
+        self.assertEquals("yum", cmd_name(argv))
+
+    def test_rhsmcertd_worker(self):
+        argv = ['/usr/libexec/rhsmcertd-worker']
+        self.assertEquals("rhsmcertd-worker", cmd_name(argv))
+
+    def test_rhsm_debug(self):
+        argv = ['/bin/rhsm-debug']
+        self.assertEquals("rhsm-debug", cmd_name(argv))
+
+    def test_virt_who(self):
+        argv = ['/usr/share/virt-who/virtwho.py']
+        self.assertEquals("virtwho.py", cmd_name(argv))
+
+    def test_rhsmd(self):
+        argv = ['/usr/libexec/rhsmd', '-i', '-f', 'valid']
+        self.assertEquals("rhsmd", cmd_name(argv))


### PR DESCRIPTION
Populate a User-Agent string to use on http
requests. It is of the form:

  "RHSM/1.0 (cmd=subscription-manager)"

The 'cmd=' will indicate the application making the
request (subscription-manager, yum, initial-setup, etc).
