### PR TITLE
1247890: KeyErrors are now caught when checking manager capabilities

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -775,9 +775,12 @@ class UEPConnection:
         """
         self.capabilities = {}
         self.capabilities = self.conn.request_get("/status/")
-        self.capabilities = self.capabilities['managerCapabilities']
-        log.debug("Server has the following capabilities: %s",
-                  self.capabilities)
+        try:
+            self.capabilities = self.capabilities['managerCapabilities']
+            log.debug("Server has the following capabilities: %s",
+                    self.capabilities)
+        except KeyError as e:
+            log.debug("Unable to retrieve managerCapabilities: %s" % str(e))
 
     def has_capability(self, capability):
         """

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -771,25 +771,23 @@ class UEPConnection:
     def _load_manager_capabilities(self):
         """
         Loads manager capabilities by doing a GET on the status
-        resource located at '/status/'
+        resource located at '/status'
         """
-        self.capabilities = {}
-        self.capabilities = self.conn.request_get("/status/")
-        try:
-            self.capabilities = self.capabilities['managerCapabilities']
-            log.debug("Server has the following capabilities: %s",
-                    self.capabilities)
-        except KeyError as e:
-            log.debug("Unable to retrieve managerCapabilities: %s" % str(e))
+        capabilities = self.getStatus().get('managerCapabilities')
+        if capabilities:
+            log.debug("Server has the following capabilities: %s", capabilities)
+        else:
+            log.debug("Unable to retrieve managerCapabilities")
+        return capabilities
 
     def has_capability(self, capability):
         """
         Check if the server we're connected to has a particular capability.
         """
-        if self.capabilities is None:
-            self._load_manager_capabilities()
+        if not self.capabilities:
+            self.capabilities = self._load_manager_capabilities()
 
-        return capability in self.capabilities
+        return capability in self.capabilities if self.capabilities else False
 
     def shutDown(self):
         self.conn.close()
@@ -861,6 +859,7 @@ class UEPConnection:
             query_params = urlencode({"owner": owner, "env": env})
             url = "/hypervisors?%s" % (query_params)
             res = self.conn.request_post(url, host_guest_mapping)
+        log.debug('lolol')
         return res
 
     def updateConsumerFacts(self, consumer_uuid, facts={}):

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -773,21 +773,26 @@ class UEPConnection:
         Loads manager capabilities by doing a GET on the status
         resource located at '/status'
         """
-        capabilities = self.getStatus().get('managerCapabilities')
-        if capabilities:
-            log.debug("Server has the following capabilities: %s", capabilities)
+        status = self.getStatus()
+        capabilities = status.get('managerCapabilities')
+        if capabilities is None:
+            log.debug("The status retrieved did not \
+                      include key 'managerCapabilities'.\nStatus:'%s'" % status)
+            capabilities = []
+        elif isinstance(capabilities, list) and not capabilities:
+            log.debug("The managerCapabilities list \
+                      was empty\nStatus:'%s'" % status)
         else:
-            log.debug("Unable to retrieve managerCapabilities")
+            log.debug("Server has the following capabilities: %s", capabilities)
         return capabilities
 
     def has_capability(self, capability):
         """
         Check if the server we're connected to has a particular capability.
         """
-        if not self.capabilities:
+        if self.capabilities is None:
             self.capabilities = self._load_manager_capabilities()
-
-        return capability in self.capabilities if self.capabilities else False
+        return capability in self.capabilities
 
     def shutDown(self):
         self.conn.close()

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -864,7 +864,6 @@ class UEPConnection:
             query_params = urlencode({"owner": owner, "env": env})
             url = "/hypervisors?%s" % (query_params)
             res = self.conn.request_post(url, host_guest_mapping)
-        log.debug('lolol')
         return res
 
     def updateConsumerFacts(self, consumer_uuid, facts={}):

--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -54,7 +54,7 @@ class ConnectionTests(unittest.TestCase):
         actual_capabilities = self.cp._load_manager_capabilities()
         self.assertEquals(sorted(actual_capabilities),
                           sorted(expected_capabilities))
-        self.assertEquals(None, self.cp._load_manager_capabilities())
+        self.assertEquals([], self.cp._load_manager_capabilities())
         self.cp.getStatus = original_getStatus
 
     def test_get_environment_by_name_requires_owner(self):

--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -37,6 +37,26 @@ class ConnectionTests(unittest.TestCase):
         self.cp = UEPConnection(username="dummy", password="dummy",
                 handler="/Test/", insecure=True)
 
+    def test_load_manager_capabilities(self):
+        expected_capabilities = ['hypervisors_async', 'cores']
+        proper_status = {'version':'1',
+                         'result':True,
+                         'managerCapabilities':expected_capabilities}
+        improper_status = dict.copy(proper_status)
+        # Remove the managerCapabilities key from the dict
+        del improper_status['managerCapabilities']
+        self.cp.conn = Mock()
+        # The first call will return the proper_status, the second, the improper
+        # status
+        original_getStatus = self.cp.getStatus
+        self.cp.getStatus = Mock(side_effect=[proper_status,
+                                                     improper_status])
+        actual_capabilities = self.cp._load_manager_capabilities()
+        self.assertEquals(sorted(actual_capabilities),
+                          sorted(expected_capabilities))
+        self.assertEquals(None, self.cp._load_manager_capabilities())
+        self.cp.getStatus = original_getStatus
+
     def test_get_environment_by_name_requires_owner(self):
         self.assertRaises(Exception, self.cp.getEnvironment, None, {"name": "env name"})
 


### PR DESCRIPTION
This accounts for the fact that candlepin and katello return different info from a GET request to their /status resources. Candlepin provides managerCapabilities while Katello does not.