### PR TITLE
Send reporter_id along with hypervisor checkins, if provided

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -885,7 +885,7 @@ class UEPConnection:
 
         return self.conn.request_post(url, params)
 
-    def hypervisorCheckIn(self, owner, env, host_guest_mapping):
+    def hypervisorCheckIn(self, owner, env, host_guest_mapping, options=None):
         """
         Sends a mapping of hostIds to list of guestIds to candlepin
         to be registered/updated.
@@ -900,7 +900,12 @@ class UEPConnection:
         if (self.has_capability("hypervisors_async")):
             priorContentType = self.conn.headers['Content-type']
             self.conn.headers['Content-type'] = 'text/plain'
-            query_params = urlencode({"env": env, "cloaked": False})
+
+            params = {"env": env, "cloaked": False}
+            if options and options.reporter_id and len(options.reporter_id) > 0:
+                params['reporter_id'] = options.reporter_id
+
+            query_params = urlencode(params)
             url = "/hypervisors/%s?%s" % (owner, query_params)
             res = self.conn.request_post(url, host_guest_mapping)
             self.conn.headers['Content-type'] = priorContentType


### PR DESCRIPTION
HypervisorCheckIn now accepts options as a keyword argument, options reporter_id is now sent if provided.

The reporter_id is used to identify the source of a hypervisor checkin.
