### PR TITLE
Let 'ssl_verify_depth' be unset and use default.

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -49,7 +49,7 @@ SERVER_DEFAULTS = {
         'prefix': DEFAULT_PREFIX,
         'port': DEFAULT_PORT,
         'insecure': '0',
-        'ssl_verify_depth': '3',
+        'ssl_verify_depth': None,
         'proxy_hostname': '',
         'proxy_user': '',
         'proxy_port': '',


### PR DESCRIPTION
We specify ssl_verify_depth=3 in the default config.
The default of the ssl implemention currently used
(openssl via m2crypto) is 100.

If we don't specify a value for ssl_verify_depth in
the config, use the default.

We do have to specify a verify_depth arg to set up
the verify with the m2crypto api, so in that case,
we get the default before we change it, and use
that is not overridden.