### PR TITLE
Updated UEPConnection.getProduct to explicitly reference product UUID

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1251,8 +1251,8 @@ class UEPConnection:
             method = "%s?consumer=%s" % (method, self.sanitize(consumerId))
         return self.conn.request_get(method)
 
-    def getProduct(self, product_id):
-        method = "/products/%s" % self.sanitize(product_id)
+    def getProduct(self, product_uuid):
+        method = "/products/%s" % self.sanitize(product_uuid)
         return self.conn.request_get(method)
 
     def getRelease(self, consumerId):


### PR DESCRIPTION
- Changed the parameter "product_id" to "product_uuid" in
  UEPConnection.getProduct to clarify which product ID needs to be
  used when looking up products. This change has no actual impact
  on the runtime operation.
