### PR TITLE
Awood/socket timeout

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -28,6 +28,7 @@ DEFAULT_CONFIG_DIR = "/etc/rhsm/"
 HOST_CONFIG_DIR = "/etc/rhsm-host/"  # symlink inside docker containers
 DEFAULT_CONFIG_PATH = "%srhsm.conf" % DEFAULT_CONFIG_DIR
 DEFAULT_PROXY_PORT = "3128"
+DEFAULT_SERVER_TIMEOUT = "180"
 
 # Defaults for connecting to RHSM, used to "reset" the configuration file
 # if requested by the user:
@@ -48,12 +49,13 @@ SERVER_DEFAULTS = {
         'hostname': DEFAULT_HOSTNAME,
         'prefix': DEFAULT_PREFIX,
         'port': DEFAULT_PORT,
+        'server_timeout': DEFAULT_SERVER_TIMEOUT,
         'insecure': '0',
         'ssl_verify_depth': '3',
         'proxy_hostname': '',
         'proxy_user': '',
         'proxy_port': '',
-        'proxy_password': ''
+        'proxy_password': '',
         }
 RHSM_DEFAULTS = {
         'baseurl': 'https://' + DEFAULT_CDN_HOSTNAME,

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -96,7 +96,7 @@ config = initConfig()
 
 def drift_check(utc_time_string, hours=1):
     """
-    Takes in a RFC 1123 date and returns True if the currnet time
+    Takes in a RFC 1123 date and returns True if the current time
     is greater then the supplied number of hours
     """
     drift = False
@@ -109,7 +109,7 @@ def drift_check(utc_time_string, hours=1):
             local_datetime = datetime.datetime.utcnow().replace(tzinfo=utc_datetime.tzinfo)
             delta = datetime.timedelta(hours=hours)
             drift = abs((utc_datetime - local_datetime)) > delta
-        except Exception, e:
+        except Exception as e:
             log.error(e)
 
     return drift
@@ -244,12 +244,10 @@ class ForbiddenException(AuthenticationException):
 
 
 class ExpiredIdentityCertException(ConnectionException):
-
     pass
 
 
 class NoOpChecker:
-
     def __init__(self, host=None, peerCertHash=None, peerCertDigest='sha1'):
         self.host = host
         self.fingerprint = peerCertHash
@@ -295,7 +293,7 @@ class ContentConnection(object):
                  ca_dir=None, insecure=False,
                  ssl_verify_depth=1):
 
-        log.debug("ContectConnection")
+        log.debug("ContentConnection")
         # FIXME
         self.ent_dir = "/etc/pki/entitlement"
         self.handler = "/"
@@ -372,12 +370,12 @@ class ContentConnection(object):
                     key_path = os.path.join(self.ent_dir, "%s-key.pem" % cert_file.split('.', 1)[0])
                     log.debug("Loading CA certificate: '%s'" % cert_path)
 
-                    #FIXME: reenable res =
+                    # FIXME: reenable res =
                     context.load_verify_info(cert_path)
                     context.load_cert(cert_path, key_path)
-                    #if res == 0:
-                    #    raise BadCertificateException(cert_path)
-        except OSError, e:
+                    # if res == 0:
+                    #     raise BadCertificateException(cert_path)
+        except OSError as e:
             raise ConnectionSetupException(e.strerror)
 
     def test(self):
@@ -508,7 +506,7 @@ class Restlib(object):
         if loaded_ca_certs:
             log.debug("Loaded CA certificates from %s: %s" % (self.ca_dir, ', '.join(loaded_ca_certs)))
 
-    # FIXME: can method be emtpty?
+    # FIXME: can method be empty?
     def _request(self, request_type, method, info=None):
         handler = self.apihandler + method
 
@@ -770,9 +768,9 @@ class UEPConnection:
         if using_basic_auth and using_id_cert_auth:
             raise Exception("Cannot specify both username/password and "
                     "cert_file/key_file")
-        #if not (using_basic_auth or using_id_cert_auth):
-        #    raise Exception("Must specify either username/password or "
-        #            "cert_file/key_file")
+        # if not (using_basic_auth or using_id_cert_auth):
+        #     raise Exception("Must specify either username/password or "
+        #         "cert_file/key_file")
 
         proxy_description = None
         if self.proxy_hostname and self.proxy_port:
@@ -1399,8 +1397,8 @@ class UEPConnection:
         return results
 
     def sanitize(self, url_param, plus=False):
-        #This is a wrapper around urllib.quote to avoid issues like the one
-        #discussed in http://bugs.python.org/issue9301
+        # This is a wrapper around urllib.quote to avoid issues like the one
+        # discussed in http://bugs.python.org/issue9301
         if plus:
             sane_string = urllib.quote_plus(str(url_param))
         else:

--- a/test/functional/connection-tests.py
+++ b/test/functional/connection-tests.py
@@ -152,9 +152,8 @@ class BindRequestTests(unittest.TestCase):
         self.consumer_uuid = consumerInfo['uuid']
 
     @patch.object(Restlib, 'validateResponse')
-    @patch.object(Restlib, 'validateResponse')
     @patch('rhsm.connection.drift_check', return_value=False)
-    @patch('M2Crypto.httpslib.HTTPSConnection', auto_spec=True)
+    @patch('rhsm.connection.HTTPSConnection', auto_spec=True)
     def test_bind_no_args(self, mock_conn, mock_drift, mock_validate):
 
         self.cp.bind(self.consumer_uuid)
@@ -169,7 +168,7 @@ class BindRequestTests(unittest.TestCase):
 
     @patch.object(Restlib, 'validateResponse')
     @patch('rhsm.connection.drift_check', return_value=False)
-    @patch('M2Crypto.httpslib.HTTPSConnection', auto_spec=True)
+    @patch('rhsm.connection.HTTPSConnection', auto_spec=True)
     def test_bind_by_pool(self, mock_conn, mock_drift, mock_validate):
         # this test is just to verify we make the httplib connection with
         # right args, we don't validate the bind here

--- a/test/functional/connection-tests.py
+++ b/test/functional/connection-tests.py
@@ -285,7 +285,7 @@ class RestlibTests(unittest.TestCase):
         try:
             self._validate_response(mock_response)
             self.fail("An exception should have been thrown.")
-        except Exception, ex:
+        except Exception as ex:
             self.assertTrue(isinstance(ex, RestlibException))
             self.assertEquals(expected_error, ex.code)
             self.assertEqual(expected_error, str(ex))
@@ -295,7 +295,7 @@ class RestlibTests(unittest.TestCase):
         try:
             self._validate_response(mock_response)
             self.fail("An %s exception should have been thrown." % expected_exception)
-        except Exception, ex:
+        except Exception as ex:
             self.assertTrue(isinstance(ex, expected_exception))
             self.assertEquals(expected_error_code, ex.code)
 

--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -13,8 +13,6 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-
-import sys
 import unittest
 
 from rhsm.connection import UEPConnection, Restlib, ConnectionException, ConnectionSetupException, \
@@ -30,7 +28,6 @@ from rhsm import ourjson as json
 
 
 class ConnectionTests(unittest.TestCase):
-
     def setUp(self):
         # NOTE: this won't actually work, idea for this suite of unit tests
         # is to mock the actual server responses and just test logic in the
@@ -163,7 +160,6 @@ class RestlibValidateResponseTests(unittest.TestCase):
                     'content': content}
         if headers:
             response['headers'] = headers
-        #print "response", response
         self.restlib.validateResponse(response, self.request_type, self.handler)
 
     # All empty responses that aren't 200/204 raise a NetworkException
@@ -198,8 +194,8 @@ class RestlibValidateResponseTests(unittest.TestCase):
 
     # MOVED PERMANENTLY
     # FIXME: implement 301 support?
-    #def test_301_empty(self):
-    #    self.vr("301", "")
+    # def test_301_empty(self):
+    #     self.vr("301", "")
 
     def test_400_empty(self):
         # FIXME: not sure 400 makes sense as "NetworkException"
@@ -215,7 +211,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
     def test_401_empty(self):
         try:
             self.vr("401", "")
-        except UnauthorizedException, e:
+        except UnauthorizedException as e:
             self.assertEquals(self.request_type, e.request_type)
             self.assertEquals("401", e.code)
             expected_str = "Server error attempting a GET to https://server/path returned status 401\n" \
@@ -228,7 +224,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
         content = u'{this is not json</> dfsdf"" '
         try:
             self.vr("401", content)
-        except UnauthorizedException, e:
+        except UnauthorizedException as e:
             self.assertEquals(self.request_type, e.request_type)
             self.assertEquals("401", e.code)
             expected_str = "Server error attempting a GET to https://server/path returned status 401\n" \
@@ -243,7 +239,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
         content = u'{"errors": ["Forbidden message"]}'
         try:
             self.vr("401", content)
-        except UnauthorizedException, e:
+        except UnauthorizedException as e:
             self.assertEquals(self.request_type, e.request_type)
             self.assertEquals("401", e.code)
             expected_str = "Server error attempting a GET to https://server/path returned status 401\n" \
@@ -256,7 +252,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
         content = u'{"errors": ["Forbidden message"]}'
         try:
             self.vr("403", content)
-        except RestlibException, e:
+        except RestlibException as e:
             self.assertEquals("403", e.code)
             self.assertEquals("Forbidden message", e.msg)
         else:
@@ -265,7 +261,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
     def test_403_empty(self):
         try:
             self.vr("403", "")
-        except ForbiddenException, e:
+        except ForbiddenException as e:
             self.assertEquals(self.request_type, e.request_type)
             self.assertEquals("403", e.code)
             expected_str = "Server error attempting a GET to https://server/path returned status 403\n" \
@@ -278,7 +274,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
         content = u'{"errors": ["Unauthorized message"]}'
         try:
             self.vr("401", content)
-        except RestlibException, e:
+        except RestlibException as e:
             self.assertEquals("401", e.code)
             self.assertEquals("Unauthorized message", e.msg)
         else:
@@ -287,7 +283,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
     def test_404_empty(self):
         try:
             self.vr("404", "")
-        except RemoteServerException, e:
+        except RemoteServerException as e:
             self.assertEquals(self.request_type, e.request_type)
             self.assertEquals(self.handler, e.handler)
             self.assertEquals("404", e.code)
@@ -299,7 +295,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
         content = u'{"something": "whatever"}'
         try:
             self.vr("404", content)
-        except RestlibException, e:
+        except RestlibException as e:
             self.assertEquals("404", e.code)
             self.assertEquals("", e.msg)
         else:
@@ -309,10 +305,10 @@ class RestlibValidateResponseTests(unittest.TestCase):
         content = u'{"displayMessage": "not found"}'
         try:
             self.vr("404", content)
-        except RestlibException, e:
+        except RestlibException as e:
             self.assertEquals("not found", e.msg)
             self.assertEquals("404", e.code)
-        except Exception, e:
+        except Exception as e:
             self.fail("RestlibException expected, got %s" % e)
         else:
             self.fail("RestlibException expected")
@@ -321,10 +317,10 @@ class RestlibValidateResponseTests(unittest.TestCase):
         content = u'{"errors": ["not found", "still not found"]}'
         try:
             self.vr("404", content)
-        except RestlibException, e:
+        except RestlibException as e:
             self.assertEquals("not found still not found", e.msg)
             self.assertEquals("404", e.code)
-        except Exception, e:
+        except Exception as e:
             self.fail("RestlibException expected, got %s" % e)
         else:
             self.fail("RestlibException expected")
@@ -332,7 +328,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
     def test_410_emtpy(self):
         try:
             self.vr("410", "")
-        except RemoteServerException, e:
+        except RemoteServerException as e:
             self.assertEquals(self.request_type, e.request_type)
             self.assertEquals(self.handler, e.handler)
         else:
@@ -340,10 +336,10 @@ class RestlibValidateResponseTests(unittest.TestCase):
 
     def test_410_body(self):
         content = u'{"displayMessage": "foo", "deletedId": "12345"}'
-        #self.assertRaises(GoneException, self.vr, "410", content)
+        # self.assertRaises(GoneException, self.vr, "410", content)
         try:
             self.vr("410", content)
-        except GoneException, e:
+        except GoneException as e:
             self.assertEquals("12345", e.deleted_id)
             self.assertEquals("foo", e.msg)
             self.assertEquals("410", e.code)
@@ -353,7 +349,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
     def test_429_empty(self):
         try:
             self.vr("429", "")
-        except RateLimitExceededException, e:
+        except RateLimitExceededException as e:
             self.assertEquals("429", e.code)
         else:
             self.fail("Should have raised a RateLimitExceededException")
@@ -363,7 +359,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
         headers = {'Retry-After': 20}
         try:
             self.vr("429", content, headers)
-        except RateLimitExceededException, e:
+        except RateLimitExceededException as e:
             self.assertEquals(20, e.retry_after)
             self.assertEquals("TooFast", e.msg)
             self.assertEquals("429", e.code)
@@ -373,7 +369,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
     def test_500_empty(self):
         try:
             self.vr("500", "")
-        except RemoteServerException, e:
+        except RemoteServerException as e:
             self.assertEquals(self.request_type, e.request_type)
             self.assertEquals(self.handler, e.handler)
         else:

--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -18,8 +18,7 @@ import unittest
 from rhsm.connection import UEPConnection, Restlib, ConnectionException, ConnectionSetupException, \
         BadCertificateException, RestlibException, GoneException, NetworkException, \
         RemoteServerException, drift_check, ExpiredIdentityCertException, UnauthorizedException, \
-        ForbiddenException, AuthenticationException, set_default_socket_timeout_if_python_2_3, \
-        RateLimitExceededException
+        ForbiddenException, AuthenticationException, RateLimitExceededException
 
 from mock import Mock, patch
 from datetime import date
@@ -34,6 +33,10 @@ class ConnectionTests(unittest.TestCase):
         # UEPConnection:
         self.cp = UEPConnection(username="dummy", password="dummy",
                 handler="/Test/", insecure=True)
+
+    def test_accepts_a_timeout(self):
+        self.cp = UEPConnection(username="dummy", password="dummy",
+                handler="/Test/", insecure=True, timeout=3)
 
     def test_load_manager_capabilities(self):
         expected_capabilities = ['hypervisors_async', 'cores']
@@ -515,33 +518,6 @@ class DriftTest(unittest.TestCase):
     def test_no_drift(self):
         header = strftime("%a, %d %b %Y %H:%M:%S GMT", gmtime())
         self.assertFalse(drift_check(header))
-
-
-class SetDefaultSocketTimeoutIfPython2_3_Test(unittest.TestCase):
-    @patch.object(sys, 'version_info', (2, 7, 5, 'final', 0))
-    @patch('socket.setdefaulttimeout', return_value=None)
-    def test_newer_than_2_3_should_not_be_altered(self, mock_setdefaulttimeout):
-
-        set_default_socket_timeout_if_python_2_3()
-        # we should only ever set default timeout on python 2.3 or earlier
-        # Elsewhere we should leave it alone, and be set to the default of None
-        # See https://bugzilla.redhat.com/show_bug.cgi?id=1195446
-
-        if sys.version_info[0] != 2:
-            self.fail("This test only passes on python 2, not python3.")
-        if sys.version_info[1] < 3:
-            self.fail("Don't expect this or any other tests to work on python 2.2 or earlier.")
-
-        self.assertFalse(mock_setdefaulttimeout.called)
-
-    @patch.object(sys, 'version_info', (2, 3, 0, 'final', 0))
-    @patch('socket.setdefaulttimeout', return_value=None)
-    def test_2_3_should_be_altered_once(self, mock_setdefaulttimeout):
-
-        set_default_socket_timeout_if_python_2_3()
-        set_default_socket_timeout_if_python_2_3()
-
-        mock_setdefaulttimeout.assert_called_once_with(60)
 
 
 class GoneExceptionTest(ExceptionTest):


### PR DESCRIPTION
This patch allows `rhsm.conf` to specify a connection timeout.  You can test by using nmap-ncat to just listen on a port without ever responding.

```
$ nc --ssl --ssl-cert /etc/candlepin/certs/candlepin-ca.crt --ssl-key /etc/candlepin/certs/candlepin-ca.key -l 8883 -k
```

In another console, use your favorite Python REPL to test:

```
In [1]: from rhsm import connection
In [2]: uep = connection.UEPConnection(host='localhost', port=8883, handler='/candlepin', insecure=True, timeout="1")
In [3]: uep.ping()
...1 second passes and you get a message "SSLTimeoutError: timed out"
In [4]: uep = connection.UEPConnection(host='localhost', port=8883, handler='/candlepin', insecure=True, timeout="10")
In [5]: uep.ping()
...10 seconds pass and you get a message "SSLTimeoutError: timed out"
```
