### PR TITLE
1315901: Exception handling for PEM cert read

### DIFF
--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -62,7 +62,11 @@ class _CertFactory(object):
         """
         Create appropriate certificate object from a PEM file on disk.
         """
-        pem = open(path, 'r').read()
+        try:
+            pem = open(path, 'r').read()
+        except IOError, e:
+            print(os.strerror(e.errno))
+            exit(1)
         return self._read_x509(_certificate.load(path), path, pem)
 
     def create_from_pem(self, pem, path=None):


### PR DESCRIPTION
Was printing a stack trace to console. It is captured and the simple message of 'Permission Denied' is output. 