### PR TITLE
Kbattula/1309828

### DIFF
--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -50,6 +50,7 @@ OID_PATTERN = re.compile('([0-9]+\.)+[0-9]+:')
 VALUE_PATTERN = re.compile('.*prim:\s(\w*)\s*:*(.*)')
 
 
+
 # NOTE: These factory methods create new style certificate objects from
 # the certificate2 module. They are placed here to abstract the fact that
 # we're using two modules for the time being. Eventually the certificate2 code


### PR DESCRIPTION
Link to bug https://bugzilla.redhat.com/show_bug.cgi?id=1309828 .

The bug reported was being unable to parse the path to check for a given certificate example at https://github.com/belonesox/certificates-wtf/blob/master/certparse.py.

This did not really seem to be a bug except for the fact that the certificate that was being tested on the bug description seemed to have been malformed in terms of the extensions not being recorded properly. I tested many paths (including /test and /content/test) on a valid certificate which seemed to work fine. The extensions were recorded to be

  = "Digital Signature, Key Encipherment, Data Encipherment"
7 = "x�MQAn�0���

MB�cU�X�*���	.�F^C��w!$�m����HR$��8�>!�5�|�K��$J6x�J;���,zB����=�Y��g4V���RN8��v��9�\?���v�#�9
�ǉ#�U[l�:�t�b�C{���X��v�cd$:-��k���i�X��Ş�$��o�x���Ϗ
C�h��l�js1�S��8.PS�#o�qDg�\:�kz8��6��P`?�)��6�Hn"��F�DvL·��	}��Kr��8(�M��q�V�z2��M�QD�d��ę�je���Z	�f%�E��M�3)�AM�
�̰�;S?J9��(�4��m�֋�E���s��ֱa��F/�4�B6�@��]ytC���Q}�ذ�@�*5Ʊ �8�G���q�
>$ȏ����H��,2Qb>C��@��"y�9�J\00�Q�7w� �8�G�0D
A����cOԋO�LGF�ȼ��o"-�h腸������Z4[�9I(�2G�����uU�е<r�E��S�\00*5�/�4�B=�X#��R	tE�Jo�_�d#�6����E�\00Tg�������F�5{`���0�.�a��F�"

For the possibly malformed certificate the extensions were

 = "Digital Signature, Key Encipherment, Data Encipherment"
7 = "x�+I-.a\00\00�`"
6 = "3.2"





