### PR TITLE
1360909: Added functionality for regenerating entitlement certificates

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -18,8 +18,7 @@
 
 import os
 from iniparse import SafeConfigParser
-from iniparse.compat import NoOptionError, InterpolationMissingOptionError, \
-        NoSectionError
+from iniparse.compat import NoOptionError, InterpolationMissingOptionError, NoSectionError
 import re
 
 CONFIG_ENV_VAR = "RHSM_CONFIG"

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1174,8 +1174,7 @@ class UEPConnection:
         This will cause the UEP to look for one or more pools which provide
         access to the given product.
         """
-        args = "&".join(["product=" + product.replace(" ", "%20")
-                        for product in products])
+        args = "&".join(["product=" + product.replace(" ", "%20") for product in products])
         method = "/consumers/%s/entitlements?%s" % (str(consumerId), args)
         return self.conn.request_post(method)
 
@@ -1344,6 +1343,22 @@ class UEPConnection:
     def regenIdCertificate(self, consumerId):
         method = "/consumers/%s" % self.sanitize(consumerId)
         return self.conn.request_post(method)
+
+    def regenEntitlementCertificates(self, consumer_id, lazy_regen=True):
+        method = "/consumers/%s/certificates" % self.sanitize(consumer_id)
+
+        if lazy_regen:
+            method += "?lazy_regen=true"
+
+        return self.conn.request_put(method)
+
+    def regenEntitlementCertificate(self, consumer_id, entitlement_id, lazy_regen=True):
+        method = "/consumers/%s/certificates?entitlement=%s" % (self.sanitize(consumer_id), self.sanitize(entitlement_id))
+
+        if lazy_regen:
+            method += "&lazy_regen=true"
+
+        return self.conn.request_put(method)
 
     def getStatus(self):
         method = "/status"


### PR DESCRIPTION
- Added two new methods for accessing Candlepin endpoints for regenerating
  entitlement certificates for a given consumer