### PR TITLE
1366301: Entitlement regeneration no longer propagates server errors

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1345,20 +1345,56 @@ class UEPConnection:
         return self.conn.request_post(method)
 
     def regenEntitlementCertificates(self, consumer_id, lazy_regen=True):
+        """
+        Regenerates all entitlements for the given consumer
+        """
+
         method = "/consumers/%s/certificates" % self.sanitize(consumer_id)
 
         if lazy_regen:
             method += "?lazy_regen=true"
 
-        return self.conn.request_put(method)
+        result = False
+
+        try:
+            self.conn.request_put(method)
+            result = True
+        except RemoteServerException as e:
+            # 404s indicate that the service is unsupported (Candlepin too old, or SAM)
+            if e.code == 404:
+                log.debug("Unable to refresh entitlement certificates: Service currently unsupported.")
+                log.debug(e)
+            else:
+                # Something else happened that we should probabaly raise
+                raise e
+
+        return result
 
     def regenEntitlementCertificate(self, consumer_id, entitlement_id, lazy_regen=True):
+        """
+        Regenerates the specified entitlement for the given consumer
+        """
+
         method = "/consumers/%s/certificates?entitlement=%s" % (self.sanitize(consumer_id), self.sanitize(entitlement_id))
 
         if lazy_regen:
             method += "&lazy_regen=true"
 
-        return self.conn.request_put(method)
+        result = False
+
+        try:
+            self.conn.request_put(method)
+            result = True
+        except RemoteServerException as e:
+            # 404s indicate that the service is unsupported (Candlepin too old, or SAM)
+            if e.code == 404:
+                log.debug("Unable to refresh entitlement certificates: Service currently unsupported.")
+                log.debug(e)
+            else:
+                # Something else happened that we should probabaly raise
+                raise e
+
+        return result
 
     def getStatus(self):
         method = "/status"

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1385,9 +1385,9 @@ class UEPConnection:
         try:
             self.conn.request_put(method)
             result = True
-        except RemoteServerException as e:
+        except (RemoteServerException, httpslib.BadStatusLine) as e:
             # 404s indicate that the service is unsupported (Candlepin too old, or SAM)
-            if e.code == 404:
+            if isinstance(e, httpslib.BadStatusLine) or e.code == 404:
                 log.debug("Unable to refresh entitlement certificates: Service currently unsupported.")
                 log.debug(e)
             else:

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1359,9 +1359,9 @@ class UEPConnection:
         try:
             self.conn.request_put(method)
             result = True
-        except RemoteServerException as e:
+        except (RemoteServerException, httpslib.BadStatusLine) as e:
             # 404s indicate that the service is unsupported (Candlepin too old, or SAM)
-            if e.code == 404:
+            if isinstance(e, httpslib.BadStatusLine) or e.code == 404:
                 log.debug("Unable to refresh entitlement certificates: Service currently unsupported.")
                 log.debug(e)
             else:

--- a/test/functional/connection-tests.py
+++ b/test/functional/connection-tests.py
@@ -159,26 +159,32 @@ class EntitlementRegenerationTests(unittest.TestCase):
         self.entitlement_id = self.entitlement['id']
 
     def test_regenerate_entitlements_default(self):
-        self.cp.regenEntitlementCertificates(self.consumer_uuid)
+        result = self.cp.regenEntitlementCertificates(self.consumer_uuid)
+        self.assertTrue(result)
 
     def test_regenerate_entitlements_lazy(self):
-        self.cp.regenEntitlementCertificates(self.consumer_uuid, True)
+        result = self.cp.regenEntitlementCertificates(self.consumer_uuid, True)
+        self.assertTrue(result)
 
     def test_regenerate_entitlements_eager(self):
-        self.cp.regenEntitlementCertificates(self.consumer_uuid, False)
+        result = self.cp.regenEntitlementCertificates(self.consumer_uuid, False)
+        self.assertTrue(result)
 
     def test_regenerate_entitlements_bad_uuid(self):
         with self.assertRaises(RestlibException):
             self.cp.regenEntitlementCertificates("bad_consumer_uuid")
 
     def test_regenerate_entitlement_default(self):
-        self.cp.regenEntitlementCertificate(self.consumer_uuid, self.entitlement_id)
+        result = self.cp.regenEntitlementCertificate(self.consumer_uuid, self.entitlement_id)
+        self.assertTrue(result)
 
     def test_regenerate_entitlement_lazy(self):
-        self.cp.regenEntitlementCertificate(self.consumer_uuid, self.entitlement_id, True)
+        result = self.cp.regenEntitlementCertificate(self.consumer_uuid, self.entitlement_id, True)
+        self.assertTrue(result)
 
     def test_regenerate_entitlement_eager(self):
-        self.cp.regenEntitlementCertificate(self.consumer_uuid, self.entitlement_id, False)
+        result = self.cp.regenEntitlementCertificate(self.consumer_uuid, self.entitlement_id, False)
+        self.assertTrue(result)
 
     def test_regenerate_entitlement_bad_consumer_uuid(self):
         with self.assertRaises(RestlibException):


### PR DESCRIPTION
- A RemoteServerException will no longer be raised from the entitlement
  certificate regeneration methods on 404
