### PR TITLE
 1367243: Fix 404 check in regen entitlement funcs

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1361,7 +1361,7 @@ class UEPConnection:
             result = True
         except (RemoteServerException, httpslib.BadStatusLine) as e:
             # 404s indicate that the service is unsupported (Candlepin too old, or SAM)
-            if isinstance(e, httpslib.BadStatusLine) or e.code == "404":
+            if isinstance(e, httpslib.BadStatusLine) or e.code == 404:
                 log.debug("Unable to refresh entitlement certificates: Service currently unsupported.")
                 log.debug(e)
             else:
@@ -1387,7 +1387,7 @@ class UEPConnection:
             result = True
         except (RemoteServerException, httpslib.BadStatusLine) as e:
             # 404s indicate that the service is unsupported (Candlepin too old, or SAM)
-            if isinstance(e, httpslib.BadStatusLine) or e.code == "404":
+            if isinstance(e, httpslib.BadStatusLine) or e.code == 404:
                 log.debug("Unable to refresh entitlement certificates: Service currently unsupported.")
                 log.debug(e)
             else:

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -1361,7 +1361,7 @@ class UEPConnection:
             result = True
         except (RemoteServerException, httpslib.BadStatusLine) as e:
             # 404s indicate that the service is unsupported (Candlepin too old, or SAM)
-            if isinstance(e, httpslib.BadStatusLine) or e.code == 404:
+            if isinstance(e, httpslib.BadStatusLine) or str(e.code) == "404":
                 log.debug("Unable to refresh entitlement certificates: Service currently unsupported.")
                 log.debug(e)
             else:
@@ -1387,7 +1387,7 @@ class UEPConnection:
             result = True
         except (RemoteServerException, httpslib.BadStatusLine) as e:
             # 404s indicate that the service is unsupported (Candlepin too old, or SAM)
-            if isinstance(e, httpslib.BadStatusLine) or e.code == 404:
+            if isinstance(e, httpslib.BadStatusLine) or str(e.code) == "404":
                 log.debug("Unable to refresh entitlement certificates: Service currently unsupported.")
                 log.debug(e)
             else:


### PR DESCRIPTION
This time, making sure status is a string before check, because without diving deeper, I fear there may be code paths/environments where it is not always a string, and this is consistent with the rest of the code.