### PR TITLE
1311429: Honor no_proxy environment variable

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -327,20 +327,19 @@ class ContentConnection(object):
         self.password = password
         self.ssl_verify_depth = ssl_verify_depth
 
-        # get the proxy information from the environment variable
-        # if available and host is not in no_proxy
+        # honor no_proxy environment variable
         if urllib.proxy_bypass_environment(self.host):
-            info = {'proxy_username': '',
-                   'proxy_hostname': '',
-                   'proxy_port': '',
-                   'proxy_password': ''}
+            self.proxy_hostname = None
+            self.proxy_port = None
+            self.proxy_user = None
+            self.proxy_password = None
         else:
             info = utils.get_env_proxy_info()
 
-        self.proxy_hostname = proxy_hostname or config.get('server', 'proxy_hostname') or info['proxy_hostname']
-        self.proxy_port = proxy_port or config.get('server', 'proxy_port') or info['proxy_port']
-        self.proxy_user = proxy_user or config.get('server', 'proxy_user') or info['proxy_username']
-        self.proxy_password = proxy_password or config.get('server', 'proxy_password') or info['proxy_password']
+            self.proxy_hostname = proxy_hostname or config.get('server', 'proxy_hostname') or info['proxy_hostname']
+            self.proxy_port = proxy_port or config.get('server', 'proxy_port') or info['proxy_port']
+            self.proxy_user = proxy_user or config.get('server', 'proxy_user') or info['proxy_username']
+            self.proxy_password = proxy_password or config.get('server', 'proxy_password') or info['proxy_password']
 
     @property
     def user_agent(self):
@@ -744,20 +743,19 @@ class UEPConnection:
         # BZ848836
         self.handler = self.handler.rstrip("/")
 
-        # get the proxy information from the environment variable
-        # if available and host is not in no_proxy
+        # honor no_proxy environment variable
         if urllib.proxy_bypass_environment(self.host):
-            info = {'proxy_username': '',
-                   'proxy_hostname': '',
-                   'proxy_port': '',
-                   'proxy_password': ''}
+            self.proxy_hostname = None
+            self.proxy_port = None
+            self.proxy_user = None
+            self.proxy_password = None
         else:
             info = utils.get_env_proxy_info()
 
-        self.proxy_hostname = proxy_hostname or config.get('server', 'proxy_hostname') or info['proxy_hostname']
-        self.proxy_port = proxy_port or config.get('server', 'proxy_port') or info['proxy_port']
-        self.proxy_user = proxy_user or config.get('server', 'proxy_user') or info['proxy_username']
-        self.proxy_password = proxy_password or config.get('server', 'proxy_password') or info['proxy_password']
+            self.proxy_hostname = proxy_hostname or config.get('server', 'proxy_hostname') or info['proxy_hostname']
+            self.proxy_port = proxy_port or config.get('server', 'proxy_port') or info['proxy_port']
+            self.proxy_user = proxy_user or config.get('server', 'proxy_user') or info['proxy_username']
+            self.proxy_password = proxy_password or config.get('server', 'proxy_password') or info['proxy_password']
 
         self.cert_file = cert_file
         self.key_file = key_file

--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -18,7 +18,7 @@ import unittest
 from rhsm.connection import UEPConnection, Restlib, ConnectionException, ConnectionSetupException, \
         BadCertificateException, RestlibException, GoneException, NetworkException, \
         RemoteServerException, drift_check, ExpiredIdentityCertException, UnauthorizedException, \
-        ForbiddenException, AuthenticationException, RateLimitExceededException
+        ForbiddenException, AuthenticationException, RateLimitExceededException, ContentConnection
 
 from mock import Mock, patch
 from datetime import date
@@ -151,6 +151,24 @@ class ConnectionTests(unittest.TestCase):
         expected_guestIds = [guestId['guestId'] for guestId in guestIds]
         self.assertEquals(expected_guestIds, resultGuestIds)
 
+    def test_uep_connection_honors_no_proxy_setting(self):
+        with patch.dict('os.environ', {'no_proxy': 'foobar'}):
+            uep = UEPConnection(host="foobar", username="dummy", password="dummy", handler="/Test/", insecure=True,
+                                proxy_hostname="proxyfoo", proxy_password="proxypass", proxy_port=42, proxy_user="foo")
+            self.assertIs(None, uep.proxy_user)
+            self.assertIs(None, uep.proxy_password)
+            self.assertIs(None, uep.proxy_hostname)
+            self.assertIs(None, uep.proxy_port)
+
+    def test_content_connection_honors_no_proxy_setting(self):
+        with patch.dict('os.environ', {'no_proxy': 'foobar'}):
+            connection = ContentConnection(host="foobar", username="dummy", password="dummy", insecure=True,
+                                           proxy_hostname="proxyfoo", proxy_password="proxypass", proxy_port=42,
+                                           proxy_user="foo")
+            self.assertIs(None, connection.proxy_user)
+            self.assertIs(None, connection.proxy_password)
+            self.assertIs(None, connection.proxy_hostname)
+            self.assertIs(None, connection.proxy_port)
 
 class RestlibValidateResponseTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This makes it such that `no_proxy` is honored unconditionally if set, whereas before, if proxy information was specified in config, then it would be used regardless of `no_proxy`.