### PR TITLE
Reduce usage of m2crypto

### DIFF
--- a/python-rhsm.spec
+++ b/python-rhsm.spec
@@ -8,6 +8,9 @@
 # simplejson is not available in RHEL 7 at all.
 %global use_simplejson (0%{?rhel} && 0%{?rhel} == 5)
 
+# on non-EOL Fedora and RHEL 7, let's not use m2crypto
+%global use_m2crypto (0%{?fedora} < 23 && 0%{?rhel} < 7)
+
 %global _hardened_build 1
 %{!?__global_ldflags: %global __global_ldflags -Wl,-z,relro -Wl,-z,now}
 
@@ -30,7 +33,9 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 %if 0%{?sles_version}
 Requires: python-m2crypto
 %else
+%if %use_m2crypto
 Requires: m2crypto
+%endif
 %endif
 Requires: python-iniparse
 Requires: rpm-python

--- a/python-rhsm.spec
+++ b/python-rhsm.spec
@@ -30,10 +30,10 @@ Source0: %{name}-%{version}.tar.gz
 URL: http://www.candlepinproject.org
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+%if %use_m2crypto
 %if 0%{?sles_version}
 Requires: python-m2crypto
 %else
-%if %use_m2crypto
 Requires: m2crypto
 %endif
 %endif

--- a/src/certificate.c
+++ b/src/certificate.c
@@ -58,10 +58,22 @@ typedef struct {
 	X509 *x509;
 } certificate_x509;
 
+typedef struct {
+	PyObject_HEAD;
+	EVP_PKEY *key;
+} private_key;
+
 static void
 certificate_x509_dealloc (certificate_x509 *self)
 {
 	X509_free (self->x509);
+	self->ob_type->tp_free ((PyObject *) self);
+}
+
+static void
+private_key_dealloc (private_key *self)
+{
+	EVP_PKEY_free (self->key);
 	self->ob_type->tp_free ((PyObject *) self);
 }
 
@@ -74,6 +86,7 @@ static PyObject *get_extension (certificate_x509 *self, PyObject *varargs,
 				PyObject *keywords);
 static PyObject *get_all_extensions (certificate_x509 *self, PyObject *varargs);
 static PyObject *as_pem (certificate_x509 *self, PyObject *varargs);
+static PyObject *as_text (certificate_x509 *self, PyObject *varargs);
 
 static PyMethodDef x509_methods[] = {
 	{"get_not_before", (PyCFunction) get_not_before, METH_VARARGS,
@@ -93,6 +106,8 @@ static PyMethodDef x509_methods[] = {
 	 "get a dict of oid: value"},
 	{"as_pem", (PyCFunction) as_pem, METH_VARARGS,
 	 "return the pem representation of this certificate"},
+	{"as_text", (PyCFunction) as_text, METH_VARARGS,
+	 "return the text representation of this certificate"},
 	{NULL}
 };
 
@@ -126,6 +141,48 @@ static PyTypeObject certificate_x509_type = {
 	0,			/* tp_iter */
 	0,			/* tp_iternext */
 	x509_methods,		/* tp_methods */
+	0,			/* tp_members */
+	0,			/* tp_getset */
+	0,			/* tp_base */
+	0,			/* tp_dict */
+	0,			/* tp_descr_get */
+	0,			/* tp_descr_set */
+	0,			/* tp_dictoffset */
+	0,			/* tp_init */
+	0,			/* tp_alloc */
+	0,			/* tp_new */
+};
+
+static PyTypeObject private_key_type = {
+	PyObject_HEAD_INIT (NULL)
+	0,
+	"_certificate.PrivateKey",
+	sizeof (private_key),
+	0,			/*tp_itemsize */
+	(destructor) private_key_dealloc,
+	0,			/*tp_print */
+	0,			/*tp_getattr */
+	0,			/*tp_setattr */
+	0,			/*tp_compare */
+	0,			/*tp_repr */
+	0,			/*tp_as_number */
+	0,			/*tp_as_sequence */
+	0,			/*tp_as_mapping */
+	0,			/*tp_hash */
+	0,			/*tp_call */
+	0,			/*tp_str */
+	0,			/*tp_getattro */
+	0,			/*tp_setattro */
+	0,			/*tp_as_buffer */
+	Py_TPFLAGS_DEFAULT,	/*tp_flags */
+	"Private Key",	    /* tp_doc */
+	0,			/* tp_traverse */
+	0,			/* tp_clear */
+	0,			/* tp_richcompare */
+	0,			/* tp_weaklistoffset */
+	0,			/* tp_iter */
+	0,			/* tp_iternext */
+	0,			/* tp_methods */
 	0,			/* tp_members */
 	0,			/* tp_getset */
 	0,			/* tp_base */
@@ -244,6 +301,40 @@ load_cert (PyObject *self, PyObject *args, PyObject *keywords)
 }
 
 static PyObject *
+load_private_key (PyObject *self, PyObject *args, PyObject *keywords)
+{
+	const char *file_name = NULL;
+	const char *pem = NULL;
+
+	static char *keywordlist[] = { "file", "pem", NULL };
+
+	if (!PyArg_ParseTupleAndKeywords (args, keywords, "|ss", keywordlist,
+					  &file_name, &pem)) {
+		return NULL;
+	}
+
+	BIO *bio;
+	if (pem != NULL) {
+		bio = BIO_new_mem_buf ((void *) pem, strlen (pem));
+	} else {
+		bio = BIO_new_file (file_name, "r");
+	}
+
+	EVP_PKEY* key = PEM_read_bio_PrivateKey (bio, NULL, NULL, NULL);
+	BIO_free (bio);
+
+	if (key == NULL) {
+		Py_INCREF (Py_None);
+		return Py_None;
+	}
+
+	private_key *py_key =
+		(private_key *) _PyObject_New (&private_key_type);
+	py_key->key = key;
+	return (PyObject *) py_key;
+}
+
+static PyObject *
 get_extension (certificate_x509 *self, PyObject *args, PyObject *keywords)
 {
 	const char *oid = NULL;
@@ -327,6 +418,26 @@ as_pem (certificate_x509 *self, PyObject *args)
 
 	BIO *bio = BIO_new (BIO_s_mem ());
 	PEM_write_bio_X509 (bio, self->x509);
+
+	size_t size = BIO_ctrl_pending (bio);
+	char *buf = malloc (sizeof (char) * size);
+	BIO_read (bio, buf, size);
+	BIO_free (bio);
+
+	PyObject *pem = PyString_FromStringAndSize (buf, size);
+	free (buf);
+	return pem;
+}
+
+static PyObject *
+as_text (certificate_x509 *self, PyObject *args)
+{
+	if (!PyArg_ParseTuple (args, "")) {
+		return NULL;
+	}
+
+	BIO *bio = BIO_new (BIO_s_mem ());
+	X509_print (bio, self->x509);
 
 	size_t size = BIO_ctrl_pending (bio);
 	char *buf = malloc (sizeof (char) * size);
@@ -451,6 +562,8 @@ get_not_after (certificate_x509 *self, PyObject *args)
 static PyMethodDef cert_methods[] = {
 	{"load", (PyCFunction) load_cert, METH_VARARGS | METH_KEYWORDS,
 	 "load a certificate from a file"},
+	{"load_private_key", (PyCFunction) load_private_key, METH_VARARGS | METH_KEYWORDS,
+	 "load a private key from a file"},
 	{NULL}
 };
 
@@ -468,4 +581,13 @@ init_certificate (void)
 	Py_INCREF (&certificate_x509_type);
 	PyModule_AddObject (module, "X509",
 			    (PyObject *) & certificate_x509_type);
+
+    private_key_type.tp_new = PyType_GenericNew;
+	if (PyType_Ready (&private_key_type) < 0) {
+		return;
+	}
+
+	Py_INCREF (&private_key_type);
+	PyModule_AddObject (module, "PrivateKey",
+			    (PyObject *) & private_key_type);
 }

--- a/src/certificate.c
+++ b/src/certificate.c
@@ -107,7 +107,7 @@ static PyMethodDef x509_methods[] = {
 	{"as_pem", (PyCFunction) as_pem, METH_VARARGS,
 	 "return the pem representation of this certificate"},
 	{"as_text", (PyCFunction) as_text, METH_VARARGS,
-	 "return the text representation of this certificate"},
+	 "return the text representation of this certificate (such as printed by openssl x509 -noout -text)"},
 	{NULL}
 };
 

--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -126,6 +126,8 @@ class Certificate(object):
     def _update(self, content):
         if content:
             x509 = _certificate.load(pem=content)
+            if x509 is None:
+                raise CertificateException("Error loading certificate")
         else:
             x509 = _certificate.X509()
         self.__ext = Extensions(x509)

--- a/src/rhsm/certificate.py
+++ b/src/rhsm/certificate.py
@@ -15,9 +15,6 @@
 
 """
 Contains classes for working with x.509 certificates.
-The backing implementation is M2Crypto.X509 which has insufficient
-support for custom v3 extensions.  It is not intended to be a
-replacement of full wrapper but instead an extension.
 
 Several of the classes in this module are now marked deprecated in favor
 of their new counterparts in certificate2 module. However, rather than
@@ -28,12 +25,12 @@ Eventually the deprecated classes below will be removed, and the new classes
 will be relocated into this module.
 """
 
+import dateutil
 import os
 import re
-from M2Crypto import X509, RSA
 from datetime import datetime as dt
 from datetime import tzinfo, timedelta
-from time import strptime
+from rhsm import _certificate
 from subprocess import Popen, PIPE, STDOUT
 import logging
 import warnings
@@ -74,43 +71,23 @@ def parse_tags(tag_str):
     return tags
 
 
-# from M2Crypto
 class UTC(tzinfo):
-    def tzname(self, date_time):
+    """UTC"""
+
+    _ZERO = timedelta(0)
+
+    def utcoffset(self, dt):
+        return self._ZERO
+
+    def tzname(self, dt):
         return "UTC"
 
-    def dst(self, date_time):
-        return timedelta(0)
-
-    def utcoffset(self, date_time):
-        return timedelta(0)
-
-    def __repr__(self):
-        return "<Timezone: %s>" % self.tzname(None)
+    def dst(self, dt):
+        return self._ZERO
 
 
-# m2Crypto available in 5.7 doesn't have the get_datetime, so
-# include the funtionality here
 def get_datetime_from_x509(date):
-    date_str = str(date)
-
-    if ' ' not in date_str:
-        raise ValueError("Invalid date: %s" % date_str)
-    month, rest = date_str.split(' ', 1)
-    _ssl_months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug",
-                   "Sep", "Oct", "Nov", "Dec"]
-
-    if month not in _ssl_months:
-        raise ValueError("Invalid date %s: Invalid month: %s" % (date_str, month))
-    if rest.endswith(' GMT'):
-        timezone = UTC()
-        rest = rest[:-4]
-
-    tm = list(strptime(rest, "%d %H:%M:%S %Y"))[:6]
-    tm[1] = _ssl_months.index(month) + 1
-    tm.append(0)
-    tm.append(timezone)
-    return dt(*tm)
+    return dateutil.parser.parse(date)
 
 
 def deprecated(func):
@@ -132,7 +109,7 @@ class Certificate(object):
     """
     Represents and x.509 certificate.
 
-    :ivar x509: The :obj:`M2Crypto.X509` backing object.
+    :ivar x509: The :obj:`X509` backing object.
     :type x509: :class:`X509`
     :ivar __ext: A dictionary of extensions `OID`:value
     :type __ext: dict of :obj:`Extensions`
@@ -148,35 +125,16 @@ class Certificate(object):
 
     def _update(self, content):
         if content:
-            x509 = X509.load_cert_string(content)
+            x509 = _certificate.load(pem=content)
         else:
-            x509 = X509.X509()
+            x509 = _certificate.X509()
         self.__ext = Extensions(x509)
         self.x509 = x509
 
-        self._parse_subject()
+        self.subj = self.x509.get_subject()
         self.serial = self.x509.get_serial_number()
 
-        self.altName = None
-        try:
-            name_ext = self.x509.get_ext('subjectAltName')
-            if name_ext:
-                self.altName = name_ext.get_value()
-        except LookupError:
-            # This may not be defined, seems to only be used for identity
-            # certificates:
-            pass
-
-    def _parse_subject(self):
-        self.subj = {}
-        subject = self.x509.get_subject()
-        subject.nid['UID'] = 458
-        for key, nid in subject.nid.items():
-            entry = subject.get_entries_by_nid(nid)
-            if len(entry):
-                asn1 = entry[0].get_data()
-                self.subj[key] = str(asn1)
-                continue
+        self.altName = x509.get_extension(name='subjectAltName')
 
     def serialNumber(self):
         """
@@ -580,9 +538,9 @@ class Key(object):
     def bogus(self):
         bogus = []
         if self.content:
-            try:
-                RSA.load_key_string(self.content)
-            except Exception:
+            # TODO handle public keys too? class docstring seems to indicate so
+            key = _certificate.load_private_key(pem=self.content)
+            if not key:
                 bogus.append("Invalid key data")
         else:
             bogus.append("No key data provided")
@@ -709,7 +667,7 @@ class Extensions(dict):
 
     def __init__(self, x509):
         """
-        :param x509: An :module:`m2crypto` :class:`X509` object or dict.
+        :param x509: An :module:`rhsm._certificate` :class:`X509` object or dict.
         :type x509: :obj:`X509`
         """
         if isinstance(x509, dict):
@@ -806,7 +764,6 @@ class Extensions(dict):
 
     def _get_extensions_block(self, x509):
         """ Isolate the block of text with the extensions. """
-        text = x509.as_text()
         p = Popen(['openssl', 'x509', '-text', '-certopt', 'ext_parse'],
                 stdout=PIPE, stdin=PIPE, stderr=STDOUT)
         text = p.communicate(input=x509.as_pem())[0]
@@ -818,7 +775,7 @@ class Extensions(dict):
 
     def _parse(self, x509):
         """
-        Parse the extensions section. Expects an :module:`m2crypto` :class:`X509` object.
+        Parse the extensions section. Expects an :module:`rhsm._certificate` :class:`X509` object.
         """
         oid = None
         for entry in self._get_extensions_block(x509):

--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -414,7 +414,7 @@ class Certificate(object):
     def __init__(self, x509=None, path=None, version=None, serial=None, start=None,
             end=None, subject=None, pem=None, issuer=None):
 
-        # The X509 M2crypto object for this certificate.
+        # The rhsm._certificate X509 object for this certificate.
         # WARNING: May be None in tests
         self.x509 = x509
 

--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -85,7 +85,7 @@ class _CertFactory(object):
             extensions = _Extensions2(x509)
             redhat_oid = OID(REDHAT_OID_NAMESPACE)
             # Trim down to only the extensions in the Red Hat namespace:
-            extensions = extensions.ltrim(len(redhat_oid))
+            extensions = extensions.branch(redhat_oid)
             # Check the certificate version, absence of the extension implies v1.0:
             cert_version_str = "1.0"
             if EXT_CERT_VERSION in extensions:

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -21,13 +21,10 @@ import dateutil.parser
 import locale
 import logging
 import os
-import socket
 import sys
 import urllib
 
-from M2Crypto import SSL, httpslib
-from M2Crypto.SSL import SSLError
-from M2Crypto import m2
+from rhsm.https import httplib, ssl
 
 from urllib import urlencode
 
@@ -218,88 +215,9 @@ class ExpiredIdentityCertException(ConnectionException):
     pass
 
 
-class NoOpChecker:
-    def __init__(self, host=None, peerCertHash=None, peerCertDigest='sha1'):
-        self.host = host
-        self.fingerprint = peerCertHash
-        self.digest = peerCertDigest
-
-    def __call__(self, peerCert, host=None):
-        return True
-
-
-class HTTPSConnection(httpslib.HTTPSConnection):
-    """M2Crypto doesn't allow us to set the timeout on the SSL connection in HTTPSConnection.
-    Therefore, we subclass."""
-    def __init__(self, host, *args, **kwargs):
-        self.rhsm_timeout = float(kwargs.pop('timeout', -1.0))
-        httpslib.HTTPSConnection.__init__(self, host, *args, **kwargs)
-
-    def connect(self):
-        """Copied verbatim except for adding the timeout"""
-        error = None
-        # We ignore the returned sockaddr because SSL.Connection.connect needs
-        # a host name.
-        for (family, _, _, _, _) in socket.getaddrinfo(self.host, self.port, 0, socket.SOCK_STREAM):
-            sock = None
-            try:
-                sock = SSL.Connection(self.ssl_ctx, family=family)
-                sock.settimeout(self.rhsm_timeout)
-                if self.session is not None:
-                    sock.set_session(self.session)
-                sock.connect((self.host, self.port))
-
-                self.sock = sock
-                sock = None
-                return
-            except socket.error as e:
-                # Other exception are probably SSL-related, in that case we
-                # abort and the exception is forwarded to the caller.
-                error = e
-            finally:
-                if sock is not None:
-                    sock.close()
-
-        if error is None:
-            raise AssertionError("Empty list returned by getaddrinfo")
-        raise error
-
-
-class RhsmProxyHTTPSConnection(httpslib.ProxyHTTPSConnection):
-    def __init__(self, host, *args, **kwargs):
-        self.rhsm_timeout = float(kwargs.pop('timeout', -1.0))
-        httpslib.ProxyHTTPSConnection.__init__(self, host, *args, **kwargs)
-
-    def _start_ssl(self):
-        self.sock = SSL.Connection(self.ssl_ctx, self.sock)
-        self.sock.settimeout(self.rhsm_timeout)
-        self.sock.setup_ssl()
-        self.sock.set_connect_state()
-        self.sock.connect_ssl()
-
-    # 2.7 httplib expects to be able to pass a body argument to
-    # endheaders, which the m2crypto.httpslib.ProxyHTTPSConnect does
-    # not support
-    def endheaders(self, body=None):
-        if not self._proxy_auth:
-            self._proxy_auth = self._encode_auth()
-
-        if body:
-            httpslib.HTTPSConnection.endheaders(self, body)
-        else:
-            httpslib.HTTPSConnection.endheaders(self)
-
-    def _get_connect_msg(self):
-        """ Return an HTTP CONNECT request to send to the proxy. """
-        port = safe_int(self._real_port)
-        msg = "CONNECT %s:%d HTTP/1.1\r\n" % (self._real_host, port)
-        msg = msg + "Host: %s:%d\r\n" % (self._real_host, port)
-        if self._proxy_UA:
-            msg = msg + "%s: %s\r\n" % (self._UA_HEADER, self._proxy_UA)
-        if self._proxy_auth:
-            msg = msg + "%s: %s\r\n" % (self._AUTH_HEADER, self._proxy_auth)
-        msg = msg + "\r\n"
-        return msg
+def _encode_auth(username, password):
+    encoded = base64.b64encode(':'.join((username, password)))
+    return 'Basic %s' % encoded
 
 
 # FIXME: this is terrible, we need to refactor
@@ -348,23 +266,22 @@ class ContentConnection(object):
 
     def _request(self, request_type, handler, body=None):
         # See note in Restlib._request
-        context = SSL.Context("sslv23")
+        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
 
         # Disable SSLv2 and SSLv3 support to avoid poodles.
-        context.set_options(m2.SSL_OP_NO_SSLv2 | m2.SSL_OP_NO_SSLv3)
+        context.options = ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3
 
         self._load_ca_certificates(context)
 
         if self.proxy_hostname and self.proxy_port:
             log.debug("Using proxy: %s:%s" % (self.proxy_hostname, self.proxy_port))
-            conn = RhsmProxyHTTPSConnection(self.proxy_hostname, self.proxy_port,
-                                            username=self.proxy_user,
-                                            password=self.proxy_password,
-                                            ssl_context=context, timeout=self.timeout)
-            # this connection class wants the full url
-            handler = "https://%s:%s%s" % (self.host, self.ssl_port, handler)
+            proxy_headers = {'User-Agent': self.user_agent}
+            if self.proxy_user and self.proxy_password:
+                proxy_headers['Proxy-Authorization'] = _encode_auth(self.proxy_user, self.proxy_password)
+            conn = httplib.HTTPSConnection(self.proxy_host, self.proxy_port, context=context, timeout=self.timeout)
+            conn.set_tunnel(self.host, safe_int(self.ssl_port), proxy_headers)
         else:
-            conn = HTTPSConnection(self.host, safe_int(self.ssl_port), ssl_context=context, timeout=self.timeout)
+            conn = httplib.HTTPSConnection(self.host, self.ssl_port, context=context, timeout=self.timeout)
 
         conn.request("GET", handler,
                      body="",
@@ -388,8 +305,8 @@ class ContentConnection(object):
                     log.debug("Loading CA certificate: '%s'" % cert_path)
 
                     # FIXME: reenable res =
-                    context.load_verify_info(cert_path)
-                    context.load_cert(cert_path, key_path)
+                    context.load_verify_locations(cert_path)
+                    context.load_cert_chain(cert_path, key_path)
                     # if res == 0:
                     #     raise BadCertificateException(cert_path)
         except OSError as e:
@@ -478,9 +395,7 @@ class Restlib(object):
 
         # Setup basic authentication if specified:
         if username and password:
-            encoded = base64.b64encode(':'.join((username, password)))
-            basic = 'Basic %s' % encoded
-            self.headers['Authorization'] = basic
+            self.headers['Authorization'] = _encode_auth(username, password)
 
     def _decode_list(self, data):
         rv = []
@@ -514,7 +429,7 @@ class Restlib(object):
             for cert_file in os.listdir(self.ca_dir):
                 if cert_file.endswith(".pem"):
                     cert_path = os.path.join(self.ca_dir, cert_file)
-                    res = context.load_verify_info(cert_path)
+                    res = context.load_verify_locations(cert_path)
                     loaded_ca_certs.append(cert_file)
                     if res == 0:
                         raise BadCertificateException(cert_path)
@@ -537,33 +452,29 @@ class Restlib(object):
         # intends to not offer sslv3, it's workable.
         #
         # So this supports tls1.2, 1.1, 1.0, and/or sslv3 if supported.
-        context = SSL.Context("sslv23")
+        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
 
         # Disable SSLv2 and SSLv3 support to avoid poodles.
-        context.set_options(m2.SSL_OP_NO_SSLv2 | m2.SSL_OP_NO_SSLv3)
+        context.options = ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3
 
         if self.insecure:  # allow clients to work insecure mode if required..
-            context.post_connection_check = NoOpChecker()
+            context.verify_mode = ssl.CERT_NONE
         else:
-            # Proper peer verification is essential to prevent MITM attacks.
-            context.set_verify(
-                    SSL.verify_peer | SSL.verify_fail_if_no_peer_cert,
-                    self.ssl_verify_depth)
+            context.verify_mode = ssl.CERT_REQUIRED
             if self.ca_dir is not None:
                 self._load_ca_certificates(context)
         if self.cert_file and os.path.exists(self.cert_file):
-            context.load_cert(self.cert_file, keyfile=self.key_file)
+            context.load_cert_chain(self.cert_file, keyfile=self.key_file)
 
         if self.proxy_hostname and self.proxy_port:
             log.debug("Using proxy: %s:%s" % (self.proxy_hostname, self.proxy_port))
-            conn = RhsmProxyHTTPSConnection(self.proxy_hostname, self.proxy_port,
-                                            username=self.proxy_user,
-                                            password=self.proxy_password,
-                                            ssl_context=context, timeout=self.timeout)
-            # this connection class wants the full url
-            handler = "https://%s:%s%s" % (self.host, self.ssl_port, handler)
+            proxy_headers = {'User-Agent': self.user_agent}
+            if self.proxy_user and self.proxy_password:
+                proxy_headers['Proxy-Authorization'] = _encode_auth(self.proxy_user, self.proxy_password)
+            conn = httplib.HTTPSConnection(self.proxy_hostname, self.proxy_port, context=context, timeout=self.timeout)
+            conn.set_tunnel(self.host, safe_int(self.ssl_port), proxy_headers)
         else:
-            conn = HTTPSConnection(self.host, self.ssl_port, ssl_context=context, timeout=self.timeout)
+            conn = httplib.HTTPSConnection(self.host, self.ssl_port, context=context, timeout=self.timeout)
 
         if info is not None:
             body = json.dumps(info, default=json.encode)
@@ -582,7 +493,7 @@ class Restlib(object):
 
         try:
             conn.request(request_type, handler, body=body, headers=headers)
-        except SSLError:
+        except ssl.SSLError:
             if self.cert_file:
                 id_cert = certificate.create_from_file(self.cert_file)
                 if not id_cert.is_valid():
@@ -1359,9 +1270,9 @@ class UEPConnection:
         try:
             self.conn.request_put(method)
             result = True
-        except (RemoteServerException, httpslib.BadStatusLine, RestlibException) as e:
+        except (RemoteServerException, httplib.BadStatusLine, RestlibException) as e:
             # 404s indicate that the service is unsupported (Candlepin too old, or SAM)
-            if isinstance(e, httpslib.BadStatusLine) or str(e.code) == "404":
+            if isinstance(e, httplib.BadStatusLine) or str(e.code) == "404":
                 log.debug("Unable to refresh entitlement certificates: Service currently unsupported.")
                 log.debug(e)
             else:
@@ -1385,9 +1296,9 @@ class UEPConnection:
         try:
             self.conn.request_put(method)
             result = True
-        except (RemoteServerException, httpslib.BadStatusLine, RestlibException) as e:
+        except (RemoteServerException, httplib.BadStatusLine, RestlibException) as e:
             # 404s indicate that the service is unsupported (Candlepin too old, or SAM)
-            if isinstance(e, httpslib.BadStatusLine) or str(e.code) == "404":
+            if isinstance(e, httplib.BadStatusLine) or str(e.code) == "404":
                 log.debug("Unable to refresh entitlement certificates: Service currently unsupported.")
                 log.debug(e)
             else:

--- a/src/rhsm/https.py
+++ b/src/rhsm/https.py
@@ -1,0 +1,63 @@
+# A compatibility wrapper that provides httplib and ssl using either standard libs or m2crypto.
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+import logging
+import ssl as _ssl
+import os
+
+log = logging.getLogger(__name__)
+
+_SSL_REQUIRED_FEATURES = [
+    'SSLContext',
+    'CERT_NONE',
+    'CERT_REQUIRED',
+    'PROTOCOL_SSLv23',
+    'OP_ALL',
+    'OP_NO_SSLv2',
+    'OP_NO_SSLv3',
+]
+
+_SSL_CONTEXT_REQUIRED_FEATURES = [
+    'check_hostname',
+    'options',
+    'verify_mode',
+]
+
+using_stdlibs = True
+for _feature in _SSL_REQUIRED_FEATURES:
+    if not hasattr(_ssl, _feature):
+        using_stdlibs = False
+
+if using_stdlibs:
+    _SslContext = _ssl.SSLContext
+    for _feature in _SSL_CONTEXT_REQUIRED_FEATURES:
+        if not hasattr(_SslContext, _feature):
+            using_stdlibs = False
+
+if 'RHSM_USE_M2CRYPTO' in os.environ:
+    using_stdlibs = os.environ['RHSM_USE_M2CRYPTO'].lower() not in ['true', '1', 'yes']
+
+if using_stdlibs:
+    log.debug('Using standard libs to provide httplib and ssl')
+    import httplib as _httplib
+    ssl = _ssl
+    httplib = _httplib
+else:
+    log.debug('Using m2crypto wrappers to provide httplib and ssl')
+    import rhsm.m2cryptossl
+    import rhsm.m2cryptohttp
+    ssl = rhsm.m2cryptossl
+    httplib = rhsm.m2cryptohttp

--- a/src/rhsm/m2cryptohttp.py
+++ b/src/rhsm/m2cryptohttp.py
@@ -1,0 +1,137 @@
+# A compatibility wrapper that adapts m2crypto to the subset of standard lib httplib used in python-rhsm.
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+from httplib import *
+from M2Crypto.httpslib import *
+from M2Crypto import httpslib, SSL
+import socket
+
+
+class _RhsmProxyHTTPSConnection(httpslib.ProxyHTTPSConnection):
+    def __init__(self, host, *args, **kwargs):
+        self.rhsm_timeout = float(kwargs.pop('timeout', -1.0))
+        self.proxy_headers = kwargs.pop('proxy_headers', None)
+        httpslib.ProxyHTTPSConnection.__init__(self, host, *args, **kwargs)
+
+    def _start_ssl(self):
+        self.sock = SSL.Connection(self.ssl_ctx, self.sock)
+        self.sock.settimeout(self.rhsm_timeout)
+        self.sock.setup_ssl()
+        self.sock.set_connect_state()
+        self.sock.connect_ssl()
+
+    # 2.7 httplib expects to be able to pass a body argument to
+    # endheaders, which the m2crypto.httpslib.ProxyHTTPSConnect does
+    # not support
+    def endheaders(self, body=None):
+        if body:
+            httpslib.HTTPSConnection.endheaders(self, body)
+        else:
+            httpslib.HTTPSConnection.endheaders(self)
+
+    def _get_connect_msg(self):
+        """ Return an HTTP CONNECT request to send to the proxy. """
+        try:
+            port = int(self._real_port)
+        except Exception:
+            port = None
+        msg = "CONNECT %s:%d HTTP/1.1\r\n" % (self._real_host, port)
+        msg += "Host: %s:%d\r\n" % (self._real_host, port)
+        if self.proxy_headers:
+            for key, value in self.proxy_headers.items():
+                msg += "%s: %s\r\n" % (key, value)
+        msg += "\r\n"
+        return msg
+
+
+class _RhsmHTTPSConnection(httpslib.HTTPSConnection):
+    def __init__(self, host, *args, **kwargs):
+        self.rhsm_timeout = float(kwargs.pop('timeout', -1.0))
+        httpslib.HTTPSConnection.__init__(self, host, *args, **kwargs)
+
+    def connect(self):
+        """Copied verbatim except for adding the timeout"""
+        error = None
+        # We ignore the returned sockaddr because SSL.Connection.connect needs
+        # a host name.
+        for (family, _, _, _, _) in socket.getaddrinfo(self.host, self.port, 0, socket.SOCK_STREAM):
+            sock = None
+            try:
+                sock = SSL.Connection(self.ssl_ctx, family=family)
+                sock.settimeout(self.rhsm_timeout)
+                if self.session is not None:
+                    sock.set_session(self.session)
+                sock.connect((self.host, self.port))
+
+                self.sock = sock
+                sock = None
+                return
+            except socket.error as e:
+                # Other exception are probably SSL-related, in that case we
+                # abort and the exception is forwarded to the caller.
+                error = e
+            finally:
+                if sock is not None:
+                    sock.close()
+
+        if error is None:
+            raise AssertionError("Empty list returned by getaddrinfo")
+        raise error
+
+
+class HTTPSConnection(object):
+    def __init__(self, host, ssl_port, *args, **kwargs):
+        self.host = host
+        self.ssl_port = ssl_port
+        context = kwargs.pop('context', None)
+        kwargs['ssl_context'] = context.m2context
+        self._connection = _RhsmHTTPSConnection(host, *args, **kwargs)
+        self.args = args
+        self.kwargs = kwargs
+
+    def request(self, method, handler, *args, **kwargs):
+        handler = "https://%s:%s%s" % (self.host, self.ssl_port, handler)
+        return self._connection.request(method, handler, *args, **kwargs)
+
+    def getresponse(self, *args, **kwargs):
+        return self._connection.getresponse(*args, **kwargs)
+
+    def set_debuglevel(self, *args, **kwargs):
+        return self._connection.set_debuglevel(*args, **kwargs)
+
+    def set_tunnel(self, host, port=None, headers=None):
+        # switch to proxy connection
+        proxy_host = self.host
+        proxy_port = self.ssl_port
+        self.host = host
+        self.ssl_port = port
+        self._connection = _RhsmProxyHTTPSConnection(proxy_host, proxy_port, *self.args, proxy_headers=headers,
+                                                    **self.kwargs)
+
+    def close(self, *args, **kwargs):
+        return self._connection.close(*args, **kwargs)
+
+    def putrequest(self, *args, **kwargs):
+        return self._connection.putrequest(*args, **kwargs)
+
+    def putheader(self, *args, **kwargs):
+        return self._connection.putheader(*args, **kwargs)
+
+    def endheaders(self, *args, **kwargs):
+        return self._connection.endheaders(*args, **kwargs)
+
+    def send(self, *args, **kwargs):
+        return self._connection.send(*args, **kwargs)

--- a/src/rhsm/m2cryptossl.py
+++ b/src/rhsm/m2cryptossl.py
@@ -1,0 +1,64 @@
+# A compatibility wrapper that adapts m2crypto to the subset of standard lib ssl used in python-rhsm.
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+
+from M2Crypto import m2 as _m2, SSL as _ssl
+
+CERT_NONE = _ssl.verify_none
+CERT_REQUIRED = _ssl.verify_peer | _ssl.verify_fail_if_no_peer_cert
+PROTOCOL_SSLv23 = 'sslv23'
+OP_ALL = _m2.SSL_OP_ALL
+OP_NO_SSLv2 = _m2.SSL_OP_NO_SSLv2
+OP_NO_SSLv3 = _m2.SSL_OP_NO_SSLv3
+
+
+class SSLContext(object):
+
+    def __init__(self, version):
+        self.m2context = _ssl.Context(version)
+        self._options = None
+        self._default_verify_depth = self.m2context.get_verify_depth()
+        self.options = OP_ALL
+        self.verify_mode = CERT_NONE
+
+    @property
+    def options(self):
+        return self._options
+
+    @options.setter
+    def options(self, options):
+        self._options = options
+        self.m2context.set_options(options)
+
+    @property
+    def verify_mode(self):
+        return self.m2context.get_verify_mode()
+
+    @verify_mode.setter
+    def verify_mode(self, verify_mode):
+        self.m2context.set_verify(verify_mode, self._default_verify_depth)
+
+    def load_verify_locations(self, cafile=None, capath=None, cadata=None):
+        if cadata:
+            raise NotImplementedError
+        return self.m2context.load_verify_locations(cafile, capath)
+
+    def load_cert_chain(self, certfile, keyfile=None, password=None):
+        if password:
+            return self.m2context.load_cert(certfile, keyfile, lambda: password)
+        else:
+            return self.m2context.load_cert(certfile, keyfile)
+
+SSLError = _ssl.SSLError

--- a/src/rhsm/m2cryptossl.py
+++ b/src/rhsm/m2cryptossl.py
@@ -1,5 +1,3 @@
-# A compatibility wrapper that adapts m2crypto to the subset of standard lib ssl used in python-rhsm.
-#
 # Copyright (c) 2016 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
@@ -13,6 +11,9 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+
+# A compatibility wrapper that adapts m2crypto to the subset of standard
+# lib ssl used in python-rhsm.
 
 from M2Crypto import m2 as _m2, SSL as _ssl
 


### PR DESCRIPTION
There are two scenarios where we were using m2crypto:
1. In order to deal with x509 operations; this patch uses the custom
   openssl bindings used for v3 certs for all certs.
2. For TLS connections; this patch uses standard libraries for TLS
   setup, when possible (and can be overridden for testing by setting
   `RHSM_USE_M2CRYPTO` to '1'/'true'/'yes'.
