### PR TITLE
1320371: Fix case of retry-after header handling

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -202,7 +202,7 @@ class RateLimitExceededException(RestlibException):
                                                          msg)
         self.headers = headers or {}
         self.msg = msg or ""
-        self.retry_after = safe_int(self.headers.get('Retry-After'))
+        self.retry_after = safe_int(self.headers.get('retry-after'))
 
 
 class UnauthorizedException(AuthenticationException):

--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -359,7 +359,7 @@ class RestlibValidateResponseTests(unittest.TestCase):
 
     def test_429_body(self):
         content = u'{"errors": ["TooFast"]}'
-        headers = {'Retry-After': 20}
+        headers = {'retry-after': 20}
         try:
             self.vr("429", content, headers)
         except RateLimitExceededException as e:


### PR DESCRIPTION
Python apparently lower-cases all headers, since headers are supposed to
be case-insensitive. Found in testing candlepin/subscription-manager#1501.