### PR TITLE
1390688: Add missing socket import

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -22,6 +22,7 @@ import httplib
 import locale
 import logging
 import os
+import socket
 import sys
 import urllib
 


### PR DESCRIPTION
Semantic merge conflict from #185 left us in a bad state. Oops!

@awood, @cnsnyder, if we could fast-track this, that'd be great, as it's causing failing tests, etc.