### PR TITLE
1394776: Fix port, insecure, and handler options on M2Crypto wrapper

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -463,8 +463,10 @@ class Restlib(object):
 
         if self.insecure:  # allow clients to work insecure mode if required..
             context.verify_mode = ssl.CERT_NONE
+            context.check_hostname = False
         else:
             context.verify_mode = ssl.CERT_REQUIRED
+            context.check_hostname = True
             if self.ca_dir is not None:
                 self._load_ca_certificates(context)
         if self.cert_file and os.path.exists(self.cert_file):
@@ -733,7 +735,7 @@ class UEPConnection:
                                 proxy_user=self.proxy_user, proxy_password=self.proxy_password,
                                 ca_dir=self.ca_cert_dir, insecure=self.insecure,
                                 ssl_verify_depth=self.ssl_verify_depth, timeout=self.timeout)
-            auth_description = "auth=identity_cert ca_dir=%s verify=%s" % (self.ca_cert_dir, self.insecure)
+            auth_description = "auth=identity_cert ca_dir=%s insecure=%s" % (self.ca_cert_dir, self.insecure)
         else:
             self.conn = Restlib(self.host, self.ssl_port, self.handler,
                     proxy_hostname=self.proxy_hostname, proxy_port=self.proxy_port,

--- a/src/rhsm/m2cryptohttp.py
+++ b/src/rhsm/m2cryptohttp.py
@@ -153,12 +153,13 @@ class HTTPSConnection(object):
         self.ssl_port = ssl_port
         context = kwargs.pop('context', None)
         kwargs['ssl_context'] = context.m2context
-        self._connection = _RhsmHTTPSConnection(host, *args, **kwargs)
+        self._connection = _RhsmHTTPSConnection(host, ssl_port, *args, **kwargs)
         self.args = args
         self.kwargs = kwargs
 
     def request(self, method, handler, *args, **kwargs):
-        handler = "https://%s:%s%s" % (self.host, self.ssl_port, handler)
+        if isinstance(self._connection, _RhsmProxyHTTPSConnection):
+            handler = "https://%s:%s%s" % (self.host, self.ssl_port, handler)
         return self._connection.request(method, handler, *args, **kwargs)
 
     def getresponse(self, *args, **kwargs):

--- a/src/rhsm/m2cryptossl.py
+++ b/src/rhsm/m2cryptossl.py
@@ -25,6 +25,16 @@ OP_NO_SSLv2 = _m2.SSL_OP_NO_SSLv2
 OP_NO_SSLv3 = _m2.SSL_OP_NO_SSLv3
 
 
+class NoOpChecker:
+    def __init__(self, host=None, peerCertHash=None, peerCertDigest='sha1'):
+        self.host = host
+        self.fingerprint = peerCertHash
+        self.digest = peerCertDigest
+
+    def __call__(self, peerCert, host=None):
+        return True
+
+
 class SSLContext(object):
 
     def __init__(self, version):
@@ -33,6 +43,19 @@ class SSLContext(object):
         self._default_verify_depth = self.m2context.get_verify_depth()
         self.options = OP_ALL
         self.verify_mode = CERT_NONE
+        self.check_hostname = False
+
+    @property
+    def check_hostname(self):
+        return self._check_hostname
+
+    @check_hostname.setter
+    def check_hostname(self, check_hostname):
+        self._check_hostname = check_hostname
+        if not check_hostname:
+            self.m2context.post_connection_check = NoOpChecker()
+        else:
+            self.m2context.post_connection_check = None
 
     @property
     def options(self):


### PR DESCRIPTION
This PR fixes a few small issues and one regression.
(In no particular order) The issues fixed are:
- change connection logging auth_description to label verify to insecure.
  I considered verify=True to be misleading (as it means here that we are not checking the certs)
- Ensure we are using the ssl_port provided on new connection creation.
- Ensure that we really are not checking for hostname matches when the insecure option is used.
  (Prior behaviour causes the insecure option to still check for hostname matches)
- Use different handlers for proxy connections vs regular connections.
  (Prior behaviour results in 404s against production and stage)
