### PR TITLE
1393010: Correlate request ID, method and handler in logs

### DIFF
--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -518,7 +518,9 @@ class Restlib(object):
         if response.getheader('x-candlepin-request-uuid'):
             response_log = "%s, requestUuid=%s" % (response_log,
                     response.getheader('x-candlepin-request-uuid'))
-        log.debug(response_log)
+        response_log = "%s, request=\"%s %s\"" % (response_log,
+            request_type, handler)
+        log.info(response_log)
 
         # Look for server drift, and log a warning
         if drift_check(response.getheader('date')):


### PR DESCRIPTION
This PR changes the following:
- the response status, request id, method and handler are now logged in the same message.
- the above log message is now logged as INFO instead of DEBUG (to ensure we more frequently have it in the logs