### PR TITLE
Fix string comparison missed in python3 PR

### DIFF
--- a/src/rhsm/certificate2.py
+++ b/src/rhsm/certificate2.py
@@ -666,7 +666,7 @@ class Product(object):
         self.architectures = architectures
         # If this is sent in as a string split it, as the field
         # can technically be multi-valued:
-        if isinstance(self.architectures, str):
+        if isinstance(self.architectures, str) or isinstance(self.architectures, type(u"")):
             self.architectures = parse_tags(self.architectures)
         if self.architectures is None:
             self.architectures = []


### PR DESCRIPTION
In the Python 3 changes, we now let things be unicode more often, but
this means that in Python 2, we need to check for string or unicode
(since the types are different in Python 2).

This fixes some test failures discovered in candlepin/subscription-manager#1520