### PR TITLE
Fix build errors on SLES11, SLES12, openSUSE

### DIFF
--- a/python-rhsm.spec
+++ b/python-rhsm.spec
@@ -31,7 +31,7 @@ URL: http://www.candlepinproject.org
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %if %use_m2crypto
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 Requires: python-m2crypto
 %else
 Requires: m2crypto
@@ -45,7 +45,7 @@ Requires: python-simplejson
 %endif
 Requires: python-rhsm-certificates = %{version}-%{release}
 
-%if 0%{?sles_version}
+%if 0%{?suse_version}
 BuildRequires: python-devel >= 2.6
 %else
 BuildRequires: python2-devel
@@ -79,7 +79,7 @@ PYTHON_RHSM_VERSION=%{version} PYTHON_RHSM_RELEASE=%{release} CFLAGS="%{optflags
 
 %install
 rm -rf %{buildroot}
-%{__python} setup.py install -O1 --skip-build --root %{buildroot}
+%{__python} setup.py install -O1 --skip-build --root %{buildroot} --prefix=%{_prefix}
 mkdir -p %{buildroot}%{_sysconfdir}/rhsm/ca
 install etc-conf/ca/*.pem %{buildroot}%{_sysconfdir}/rhsm/ca
 


### PR DESCRIPTION
Testing
---------

goal of this PR is enabling builds, so easiest thing to do is a tito build...

 - Can install tito w/ SUSE patches on a opensuse machine via `git+https://github.com/kahowell/tito@master#egg=tito`.
 - Can install build deps via source RPM from http://download.opensuse.org/repositories/home:/kahowell/openSUSE_Leap_42.2/src/
 - with deps installed, you can do the usual `tito build --rpm --test`