### PR TITLE
1420533: Add no_proxy option to API and config

### DIFF
--- a/src/rhsm/config.py
+++ b/src/rhsm/config.py
@@ -55,6 +55,7 @@ SERVER_DEFAULTS = {
         'proxy_user': '',
         'proxy_port': '',
         'proxy_password': '',
+        'no_proxy': '',
         }
 RHSM_DEFAULTS = {
         'baseurl': 'https://' + DEFAULT_CDN_HOSTNAME,

--- a/src/rhsm/connection.py
+++ b/src/rhsm/connection.py
@@ -238,7 +238,7 @@ class ContentConnection(object):
                  proxy_hostname=None, proxy_port=None,
                  proxy_user=None, proxy_password=None,
                  ca_dir=None, insecure=False,
-                 ssl_verify_depth=1, timeout=None):
+                 ssl_verify_depth=1, timeout=None, no_proxy=None):
 
         log.debug("ContentConnection")
         # FIXME
@@ -254,6 +254,11 @@ class ContentConnection(object):
         self.username = username
         self.password = password
         self.ssl_verify_depth = ssl_verify_depth
+
+        # allow specifying no_proxy via api or config
+        no_proxy_override = no_proxy or config.get('server', 'no_proxy')
+        if no_proxy_override:
+            os.environ['no_proxy'] = no_proxy_override
 
         # honor no_proxy environment variable
         if proxy_bypass_environment(self.host):
@@ -651,7 +656,8 @@ class UEPConnection:
             cert_file=None, key_file=None,
             insecure=None,
             timeout=None,
-            restlib_class=None):
+            restlib_class=None,
+            no_proxy=None):
         """
         Two ways to authenticate:
             - username/password for HTTP basic authentication. (owner admin role)
@@ -669,6 +675,11 @@ class UEPConnection:
         # remove trailing "/" from the prefix if it is there
         # BZ848836
         self.handler = self.handler.rstrip("/")
+
+        # allow specifying no_proxy via api or config
+        no_proxy_override = no_proxy or config.get('server', 'no_proxy')
+        if no_proxy_override:
+            os.environ['no_proxy'] = no_proxy_override
 
         # honor no_proxy environment variable
         if proxy_bypass_environment(self.host):

--- a/test/unit/connection-tests.py
+++ b/test/unit/connection-tests.py
@@ -17,6 +17,7 @@ import datetime
 import locale
 import unittest
 
+from rhsm import connection
 from rhsm.connection import UEPConnection, Restlib, ConnectionException, ConnectionSetupException, \
         BadCertificateException, RestlibException, GoneException, NetworkException, \
         RemoteServerException, drift_check, ExpiredIdentityCertException, UnauthorizedException, \
@@ -122,6 +123,51 @@ class ConnectionTests(unittest.TestCase):
             self.assertEquals(None, uep.proxy_password)
             self.assertEquals("host", uep.proxy_hostname)
             self.assertEquals(int("1111"), uep.proxy_port)
+
+    def test_no_proxy_via_api(self):
+        """Test that API trumps env var and config."""
+        host = self.cp.host
+        port = self.cp.ssl_port
+
+        def mock_config(section, name):
+            if (section, name) == ('server', 'no_proxy'):
+                return 'foo.example.com'
+            if (section, name) == ('server', 'hostname'):
+                return host
+            if (section, name) == ('server', 'port'):
+                return port
+            return None
+
+        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host', 'NO_PROXY': 'foo.example.com'}):
+            with patch.object(connection.config, 'get', mock_config):
+                uep = UEPConnection(username='dummy', password='dummy', handler='/test', insecure=True, no_proxy=host)
+                self.assertEqual(None, uep.proxy_hostname)
+
+    def test_no_proxy_via_environment_variable(self):
+        """Test that env var no_proxy works."""
+        host = self.cp.host
+        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host', 'NO_PROXY': host}):
+            uep = UEPConnection(username='dummy', password='dummy', handler='/test', insecure=True)
+            self.assertEqual(None, uep.proxy_hostname)
+
+    def test_no_proxy_via_config(self):
+        """Test that config trumps env var."""
+        host = self.cp.host
+        port = self.cp.ssl_port
+
+        def mock_config(section, name):
+            if (section, name) == ('server', 'no_proxy'):
+                return host
+            if (section, name) == ('server', 'hostname'):
+                return host
+            if (section, name) == ('server', 'port'):
+                return port
+            return None
+
+        with patch.dict('os.environ', {'HTTPS_PROXY': 'http://u:p@host', 'NO_PROXY': 'foo.example.com'}):
+            with patch.object(connection.config, 'get', mock_config):
+                uep = UEPConnection(username='dummy', password='dummy', handler='/test', insecure=True)
+                self.assertEqual(None, uep.proxy_hostname)
 
     def test_sanitizeGuestIds_supports_strs(self):
         self.cp.supports_resource = Mock(return_value=True)


### PR DESCRIPTION
Adding `no_proxy` to both config file and API makes it more consistent
with other proxy options, in that it can be specified in environment,
config, or by code, and lookup is consistent for all proxy options
(API preferred over config, config preferred over environment).

Will rebase in subscription-manager repo assuming candlepin/subscription-manager#1549 lands.