### PR TITLE
Add iniparse as install_requirement; ENT-2199

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,4 +120,5 @@ setup(
         'Intended Audience :: Information Technology',
         'Programming Language :: Python'
     ],
+    install_requires=['iniparse'],
 )


### PR DESCRIPTION
To better support those users of the legacy version of python-rhsm as available on pypi, I've added "iniparse" as an install time requirement.

P.s. I don't think jenkins is set up to perform the two checks on these PRs anymore. We might need to modify the requirement for them.